### PR TITLE
Gpuciscripts clean and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 GPUTreeShap is a cuda implementation of the TreeShap algorithm by Lundberg et al. [1] for Nvidia GPUs. It is a header only module designed to be included in decision tree libraries as a fast backend for model interpretability using SHAP values.
 
+See the associated publication [here](https://arxiv.org/abs/2010.13972)
+```
+@misc{mitchell2020gputreeshap,
+      title={GPUTreeShap: Fast Parallel Tree Interpretability}, 
+      author={Rory Mitchell and Eibe Frank and Geoffrey Holmes},
+      year={2020},
+      eprint={2010.13972},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
 ## Performance
 Using the benchmark script `benchmark/benchmark.py` we run GPUTreeShap as a backend for xgboost and compare its performance against multithreaded CPU based implementation. Test models are generated on four different datasets at different sizes. The below comparison is run on an Nvidia DGX-1 system, comparing a single V100 to 2X 20-Core Intel Xeon
 E5-2698 CPUs (40 physical cores total).

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -6,11 +6,12 @@
 
 # Ignore errors and set path
 set +e
-PATH=/conda/bin:$PATH
+PATH=/opt/conda/bin:$PATH
 RETVAL="0"
 
 # Activate common conda env
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 # Check for a consistent code format
 pip install cpplint

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -8,14 +8,9 @@ set -e
 NUMARGS=$#
 ARGS=$*
 
-# Logger function for build status output
-function gpuci_logger() {
-  echo -e "\n>>>> $@\n"
-}
-
 # Set path and build parallel level
 export PATH=/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=-4
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 export CUDA_REL=${CUDA_VERSION%.*}
 
 # Set home to the job's workspace

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -9,13 +9,13 @@ NUMARGS=$#
 ARGS=$*
 
 # Logger function for build status output
-function logger() {
+function gpuci_logger() {
   echo -e "\n>>>> $@\n"
 }
 
 # Set path and build parallel level
 export PATH=/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=4
+export PARALLEL_LEVEL=-4
 export CUDA_REL=${CUDA_VERSION%.*}
 
 # Set home to the job's workspace
@@ -26,7 +26,7 @@ export HOME=$WORKSPACE
 # SETUP - Check environment
 ################################################################################
 
-logger "Install cmake..."
+gpuci_logger "Install cmake"
 mkdir cmake
 cd cmake
 wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.sh
@@ -34,7 +34,7 @@ sh cmake-3.18.2-Linux-x86_64.sh --skip-license
 export PATH=$PATH:$PWD/bin
 cd ..
 
-logger "Install gtest..."
+gpuci_logger "Install gtest"
 wget https://github.com/google/googletest/archive/release-1.10.0.zip
 unzip release-1.10.0.zip
 mv googletest-release-1.10.0 gtest && cd gtest
@@ -43,11 +43,11 @@ cp -r googletest/include include
 export GTEST_ROOT=$PWD
 cd ..
 
-logger "Check environment..."
+gpuci_logger "Check environment"
 env
 
 
-logger "Check GPU usage..."
+gpuci_logger "Check GPU usage"
 nvidia-smi
 
 $CC --version
@@ -57,7 +57,7 @@ $CXX --version
 # BUILD - Build tests
 ################################################################################
 
-logger "Build C++ targets..."
+gpuci_logger "Build C++ targets"
 mkdir $WORKSPACE/build
 cd $WORKSPACE/build
 cmake .. -DBUILD_GTEST=ON -DBUILD_EXAMPLES=ON
@@ -67,13 +67,13 @@ make -j
 # TEST - Run GoogleTest
 ################################################################################
 
-logger "GoogleTest..."
+gpuci_logger "GoogleTest"
 cd $WORKSPACE/build
 ./TestGPUTreeShap
 
 ################################################################################
 # Run example
 ################################################################################
-logger "Example..."
+gpuci_logger "Example"
 cd $WORKSPACE/build
 ./GPUTreeShapExample

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -16,8 +16,10 @@ export CUDA_REL=${CUDA_VERSION%.*}
 # Set home to the job's workspace
 export HOME=$WORKSPACE
 
+# Install gpuCI tools
 curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh | bash
-
+source ~/.bashrc
+cd ~
 
 ################################################################################
 # SETUP - Check environment

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -16,6 +16,8 @@ export CUDA_REL=${CUDA_VERSION%.*}
 # Set home to the job's workspace
 export HOME=$WORKSPACE
 
+curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh | bash
+
 
 ################################################################################
 # SETUP - Check environment


### PR DESCRIPTION

In CI folder the following changes have been made:

- Remove logger function and replace all logger calls with gpuci_logger

- Removed all ellipses ... from logger messages

- Prepend /opt to the conda path in PATH variable

- Replace conda with gpuci_conda_retry for build and install calls  (Did not replace conda activate with gpuci_conda_retry) 

- Replace source activate <env> with the following:
. /opt/conda/etc/profile.d/conda.sh
conda activate rapids

- Replace conda list with more verbose information:
conda info
conda config --show-sources
conda list --show-channel-urls

- Update Copyright year in the top of scripts to include 2020 if applicable

- Set PARALLEL_LEVEL to ${PARALLEL_LEVEL:-4}

- Set gpuci_conda_retry flags in cpu/build.sh
Setup 'gpuci_conda_retry' for build retries (results in 2 total attempts)
export GPUCI_CONDA_RETRY_MAX=1
export GPUCI_CONDA_RETRY_SLEEP=30

- Replace calls to gcc and g++ with $CC and $CXX respectively