### PR TITLE
Remove pointer check

### DIFF
--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -88,16 +88,6 @@ using RebindVector =
     thrust::device_vector<T,
                           typename DeviceAllocatorT::template rebind<T>::other>;
 
-template <typename PtrT>
-bool IsDeviceAccessible(PtrT ptr) {
-  cudaPointerAttributes attributes;
-  cudaPointerGetAttributes(&attributes, ptr);
-  auto error = cudaGetLastError();
-  if (error == cudaErrorInvalidValue) {
-    return false;
-  }
-  return attributes.type != cudaMemoryTypeUnregistered;
-}
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600 || defined(__clang__)
 __device__ __forceinline__ double atomicAddDouble(double* address,
                                                   double val) {
@@ -1026,10 +1016,6 @@ void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
         "num_groups");
   }
 
-  if (!detail ::IsDeviceAccessible(phis_out)) {
-    throw std::invalid_argument("phis_out must be device accessible");
-  }
-
   using size_vector = detail::RebindVector<size_t, DeviceAllocatorT>;
   using double_vector = detail::RebindVector<double, DeviceAllocatorT>;
   using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
@@ -1106,10 +1092,6 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1)  * "
         "(X.NumCols() + 1) * "
         "num_groups");
-  }
-
-  if (!detail::IsDeviceAccessible(phis_out)) {
-    throw std::invalid_argument("phis_out must be device accessible");
   }
 
   using size_vector = detail::RebindVector<size_t, DeviceAllocatorT>;
@@ -1189,10 +1171,6 @@ void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1)  * "
         "(X.NumCols() + 1) * "
         "num_groups");
-  }
-
-  if (!detail ::IsDeviceAccessible(phis_out)) {
-    throw std::invalid_argument("phis_out must be device accessible");
   }
 
   using size_vector = detail::RebindVector<size_t, DeviceAllocatorT>;

--- a/tests/test_gpu_treeshap.cu
+++ b/tests/test_gpu_treeshap.cu
@@ -340,22 +340,6 @@ TEST_F(APITest, PhisIncorrectLength) {
   ExpectAPIThrow<std::invalid_argument>("phis_out must be at least of size");
 }
 
-TEST_F(APITest, PhisIncorrectMemory) {
-  std::vector<float> phis_host(phis.size());
-  std::string message = "phis_out must be device accessible";
-  EXPECT_THROW_CONTAINS_MESSAGE(GPUTreeShap(X, model.begin(), model.end(), 1,
-                                            phis_host.data(), phis.size()),
-                                std::invalid_argument, message);
-  EXPECT_THROW_CONTAINS_MESSAGE(
-      GPUTreeShapInteractions(X, model.begin(), model.end(), 1,
-                              phis_host.data(), phis.size()),
-      std::invalid_argument, message);
-  EXPECT_THROW_CONTAINS_MESSAGE(
-      GPUTreeShapTaylorInteractions(X, model.begin(), model.end(), 1,
-                                    phis_host.data(), phis.size()),
-      std::invalid_argument, message);
-}
-
 // Test a simple tree and compare output to xgb shap values
 // 0:[f0<0.5] yes=1,no=2,missing=1,gain=1.63333321,cover=5
 //  1:leaf=-1,cover=2


### PR DESCRIPTION
This pointer check appears to trigger stack smashing errors when used as a c extension with shap: https://github.com/slundberg/shap/pull/1571.