### PR TITLE
Api updates

### DIFF
--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -18,31 +18,72 @@
 #include <thrust/device_allocator.h>
 #include <thrust/device_vector.h>
 #include <thrust/iterator/discard_iterator.h>
-#include <thrust/reduce.h>
 #include <thrust/logical.h>
-#include <stdexcept>
+#include <thrust/reduce.h>
 #include <algorithm>
 #include <functional>
+#include <set>
+#include <stdexcept>
 #include <utility>
 #include <vector>
-#include <set>
-
 
 namespace gpu_treeshap {
-/*! An element of a unique path through a decision tree. */
-struct PathElement {
-  __host__ __device__ PathElement(size_t path_idx, int64_t feature_idx,
-                                  int group, float feature_lower_bound,
-                                  float feature_upper_bound,
-                                  bool is_missing_branch, double zero_fraction,
-                                  float v)
-      : path_idx(path_idx), feature_idx(feature_idx), group(group),
-        feature_lower_bound(feature_lower_bound),
+
+struct XgboostSplitCondition {
+  XgboostSplitCondition() = default;
+  XgboostSplitCondition(float feature_lower_bound, float feature_upper_bound,
+                        bool is_missing_branch)
+      : feature_lower_bound(feature_lower_bound),
         feature_upper_bound(feature_upper_bound),
-        is_missing_branch(is_missing_branch), zero_fraction(zero_fraction),
-        v(v) {
+        is_missing_branch(is_missing_branch) {
     assert(feature_lower_bound <= feature_upper_bound);
   }
+
+  /*! Feature values >= lower and < upper flow down this path. */
+  float feature_lower_bound;
+  float feature_upper_bound;
+  /*! Do missing values flow down this path? */
+  bool is_missing_branch;
+
+  // Does this instance flow down this path?
+  __host__ __device__ bool EvaluateSplit(float x) const {
+    if (isnan(x)) {
+      return is_missing_branch;
+    }
+    return x >= feature_lower_bound && x < feature_upper_bound;
+  }
+
+  // Combine two split conditions on the same feature
+  __host__ __device__ void Merge(
+      const XgboostSplitCondition& other) {  // Combine duplicate features
+    feature_lower_bound = max(feature_lower_bound, other.feature_lower_bound);
+    feature_upper_bound = min(feature_upper_bound, other.feature_upper_bound);
+    is_missing_branch = is_missing_branch && other.is_missing_branch;
+  }
+};
+
+/*!
+ * An element of a unique path through a decision tree. Can implement various
+ * types of splits via the templated SplitConditionT. Some decision tree
+ * implementations may wish to use double precision or single precision, some
+ * may use < or <= as the threshold, missing values can be handled differently,
+ * categoricals may be supported.
+ *
+ * \tparam  SplitConditionT A split condition implementing the methods
+ * EvaluateSplit and Merge.
+ */
+template <typename SplitConditionT>
+struct PathElement {
+  using split_type = SplitConditionT;
+  __host__ __device__ PathElement(size_t path_idx, int64_t feature_idx,
+                                  int group, SplitConditionT split_condition,
+                                  double zero_fraction, float v)
+      : path_idx(path_idx),
+        feature_idx(feature_idx),
+        group(group),
+        split_condition(split_condition),
+        zero_fraction(zero_fraction),
+        v(v) {}
 
   PathElement() = default;
   __host__ __device__ bool IsRoot() const { return feature_idx == -1; }
@@ -52,11 +93,7 @@ struct PathElement {
   int64_t feature_idx;
   /*! Indicates class for multiclass problems. */
   int group;
-  /*! Feature values >= lower and < upper flow down this path. */
-  float feature_lower_bound;
-  float feature_upper_bound;
-  /*! Do missing values flow down this path? */
-  bool is_missing_branch;
+  SplitConditionT split_condition;
   /*! Probability of following this path when feature_idx is not in the active
    * set. */
   double zero_fraction;
@@ -121,8 +158,7 @@ using RebindVector =
                           typename DeviceAllocatorT::template rebind<T>::other>;
 
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600 || defined(__clang__)
-__device__ __forceinline__ double atomicAddDouble(double* address,
-                                                  double val) {
+__device__ __forceinline__ double atomicAddDouble(double* address, double val) {
   return atomicAdd(address, val);
 }
 #else  // In device code and CUDA < 600
@@ -135,7 +171,7 @@ __device__ __forceinline__ double atomicAddDouble(double* address,
   do {
     assumed = old;
     old = atomicCAS(address_as_ull, assumed,
-      __double_as_longlong(val + __longlong_as_double(assumed)));
+                    __double_as_longlong(val + __longlong_as_double(assumed)));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN !=
     // NaN)
@@ -144,7 +180,6 @@ __device__ __forceinline__ double atomicAddDouble(double* address,
   return __longlong_as_double(old);
 }
 #endif
-
 
 __forceinline__ __device__ unsigned int lanemask32_lt() {
   unsigned int lanemask32_lt;
@@ -214,21 +249,6 @@ inline __device__ ContiguousGroup active_labeled_partition(uint32_t mask,
   }
 #endif
   return ContiguousGroup(subgroup_mask);
-}
-
-template <typename DatasetT>
-__device__ float GetOneFraction(const PathElement& e, const DatasetT& X,
-                                size_t row_idx) {
-  // First element in path (bias term) is always zero
-  if (e.feature_idx == -1) return 0.0;
-  // Test the split
-  // Does the training instance continue down this path if the feature is
-  // present?
-  float val = X.GetElement(row_idx, e.feature_idx);
-  if (isnan(val)) {
-    return e.is_missing_branch;
-  }
-  return val >= e.feature_lower_bound && val < e.feature_upper_bound;
 }
 
 // Group of threads where each thread holds a path element
@@ -305,7 +325,7 @@ class GroupPath {
 
 // Has different permutation weightings to the above
 // Used in Taylor Shapley interaction index
-class TaylorGroupPath:GroupPath {
+class TaylorGroupPath : GroupPath {
  public:
   __device__ TaylorGroupPath(const ContiguousGroup& g, float zero_fraction,
                              float one_fraction)
@@ -348,11 +368,12 @@ class TaylorGroupPath:GroupPath {
   }
 };
 
-template <typename DatasetT>
-__device__ float ComputePhi(const PathElement& e, size_t row_idx,
-                            const DatasetT& X, const ContiguousGroup& group,
-                            float zero_fraction) {
-  float one_fraction = GetOneFraction(e, X, row_idx);
+template <typename DatasetT, typename SplitConditionT>
+__device__ float ComputePhi(const PathElement<SplitConditionT>& e,
+                            size_t row_idx, const DatasetT& X,
+                            const ContiguousGroup& group, float zero_fraction) {
+  float one_fraction =
+      e.split_condition.EvaluateSplit(X.GetElement(row_idx, e.feature_idx));
   GroupPath path(group, zero_fraction, one_fraction);
   size_t unique_path_length = group.size();
 
@@ -370,12 +391,13 @@ inline __host__ __device__ size_t DivRoundUp(size_t a, size_t b) {
   return (a + b - 1) / b;
 }
 
-template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp>
-void __device__ ConfigureThread(const DatasetT& X, const size_t bins_per_row,
-                            const PathElement* path_elements,
-                            const size_t* bin_segments, size_t* start_row,
-                            size_t* end_row, PathElement* e,
-                            bool* thread_active) {
+template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp,
+          typename SplitConditionT>
+void __device__
+ConfigureThread(const DatasetT& X, const size_t bins_per_row,
+                const PathElement<SplitConditionT>* path_elements,
+                const size_t* bin_segments, size_t* start_row, size_t* end_row,
+                PathElement<SplitConditionT>* e, bool* thread_active) {
   // Partition work
   // Each warp processes a set of training instances applied to a path
   size_t tid = kBlockSize * blockIdx.x + threadIdx.x;
@@ -403,16 +425,17 @@ void __device__ ConfigureThread(const DatasetT& X, const size_t bins_per_row,
 #define GPUTREESHAP_MAX_THREADS_PER_BLOCK 256
 #define FULL_MASK 0xffffffff
 
-template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp>
+template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp,
+          typename SplitConditionT>
 __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
     ShapKernel(DatasetT X, size_t bins_per_row,
-               const PathElement* path_elements, const size_t* bin_segments,
-               size_t num_groups, double* phis) {
+               const PathElement<SplitConditionT>* path_elements,
+               const size_t* bin_segments, size_t num_groups, double* phis) {
   // Use shared memory for structs, otherwise nvcc puts in local memory
   __shared__ DatasetT s_X;
   s_X = X;
-  __shared__ PathElement s_elements[kBlockSize];
-  PathElement& e = s_elements[threadIdx.x];
+  __shared__ PathElement<SplitConditionT> s_elements[kBlockSize];
+  PathElement<SplitConditionT>& e = s_elements[threadIdx.x];
 
   size_t start_row, end_row;
   bool thread_active;
@@ -430,17 +453,19 @@ __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
 
     if (!e.IsRoot()) {
       atomicAddDouble(&phis[IndexPhi(row_idx, num_groups, e.group, X.NumCols(),
-                                       e.feature_idx)],
+                                     e.feature_idx)],
                       phi);
     }
   }
 }
 
-template <typename DatasetT, typename SizeTAllocatorT, typename PathAllocatorT>
+template <typename DatasetT, typename SizeTAllocatorT, typename PathAllocatorT,
+          typename SplitConditionT>
 void ComputeShap(
     DatasetT X,
     const thrust::device_vector<size_t, SizeTAllocatorT>& bin_segments,
-    const thrust::device_vector<PathElement, PathAllocatorT>& path_elements,
+    const thrust::device_vector<PathElement<SplitConditionT>, PathAllocatorT>&
+        path_elements,
     size_t num_groups, double* phis) {
   size_t bins_per_row = bin_segments.size() - 1;
   const int kBlockThreads = GPUTREESHAP_MAX_THREADS_PER_BLOCK;
@@ -456,11 +481,13 @@ void ComputeShap(
           bin_segments.data().get(), num_groups, phis);
 }
 
-template <typename PathT, typename DatasetT>
-__device__ float  ComputePhiCondition(const PathElement& e, size_t row_idx,
-  const DatasetT& X, const ContiguousGroup& group,
-                                    int64_t condition_feature) {
-  float one_fraction = GetOneFraction(e, X, row_idx);
+template <typename PathT, typename DatasetT, typename SplitConditionT>
+__device__ float ComputePhiCondition(const PathElement<SplitConditionT>& e,
+                                     size_t row_idx, const DatasetT& X,
+                                     const ContiguousGroup& group,
+                                     int64_t condition_feature) {
+  float one_fraction =
+      e.split_condition.EvaluateSplit(X.GetElement(row_idx, e.feature_idx));
   PathT path(group, e.zero_fraction, one_fraction);
   size_t unique_path_length = group.size();
   float condition_on_fraction = 1.0f;
@@ -490,10 +517,10 @@ __device__ float  ComputePhiCondition(const PathElement& e, size_t row_idx,
 
 // If there is a feature in the path we are conditioning on, swap it to the end
 // of the path
-inline __device__ void SwapConditionedElement(PathElement** e,
-                                              PathElement* s_elements,
-                                              uint32_t condition_rank,
-                                              const ContiguousGroup& group) {
+template <typename SplitConditionT>
+inline __device__ void SwapConditionedElement(
+    PathElement<SplitConditionT>** e, PathElement<SplitConditionT>* s_elements,
+    uint32_t condition_rank, const ContiguousGroup& group) {
   auto last_rank = group.size() - 1;
   auto this_rank = group.thread_rank();
   if (this_rank == last_rank) {
@@ -503,17 +530,18 @@ inline __device__ void SwapConditionedElement(PathElement** e,
   }
 }
 
-template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp>
+template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp,
+          typename SplitConditionT>
 __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
     ShapInteractionsKernel(DatasetT X, size_t bins_per_row,
-                           const PathElement* path_elements,
+                           const PathElement<SplitConditionT>* path_elements,
                            const size_t* bin_segments, size_t num_groups,
                            double* phis_interactions) {
   // Use shared memory for structs, otherwise nvcc puts in local memory
   __shared__ DatasetT s_X;
   s_X = X;
-  __shared__ PathElement s_elements[kBlockSize];
-  PathElement* e = &s_elements[threadIdx.x];
+  __shared__ PathElement<SplitConditionT> s_elements[kBlockSize];
+  PathElement<SplitConditionT>* e = &s_elements[threadIdx.x];
 
   size_t start_row, end_row;
   bool thread_active;
@@ -541,7 +569,7 @@ __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
           labelled_group.shfl(e->feature_idx, condition_rank);
       SwapConditionedElement(&e, s_elements, condition_rank, labelled_group);
       float x = ComputePhiCondition<GroupPath>(*e, row_idx, X, labelled_group,
-                                    condition_feature);
+                                               condition_feature);
       if (!e->IsRoot()) {
         auto phi_offset =
             IndexPhiInteractions(row_idx, num_groups, e->group, X.NumCols(),
@@ -557,11 +585,13 @@ __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
   }
 }
 
-template <typename DatasetT, typename SizeTAllocatorT, typename PathAllocatorT>
+template <typename DatasetT, typename SizeTAllocatorT, typename PathAllocatorT,
+          typename SplitConditionT>
 void ComputeShapInteractions(
     DatasetT X,
     const thrust::device_vector<size_t, SizeTAllocatorT>& bin_segments,
-    const thrust::device_vector<PathElement, PathAllocatorT>& path_elements,
+    const thrust::device_vector<PathElement<SplitConditionT>, PathAllocatorT>&
+        path_elements,
     size_t num_groups, double* phis) {
   size_t bins_per_row = bin_segments.size() - 1;
   const int kBlockThreads = GPUTREESHAP_MAX_THREADS_PER_BLOCK;
@@ -577,20 +607,22 @@ void ComputeShapInteractions(
           bin_segments.data().get(), num_groups, phis);
 }
 
-template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp>
+template <typename DatasetT, size_t kBlockSize, size_t kRowsPerWarp,
+          typename SplitConditionT>
 __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
-    ShapTaylorInteractionsKernel(DatasetT X, size_t bins_per_row,
-                           const PathElement* path_elements,
-                           const size_t* bin_segments, size_t num_groups,
-                           double* phis_interactions) {
+    ShapTaylorInteractionsKernel(
+        DatasetT X, size_t bins_per_row,
+        const PathElement<SplitConditionT>* path_elements,
+        const size_t* bin_segments, size_t num_groups,
+        double* phis_interactions) {
   // Use shared memory for structs, otherwise nvcc puts in local memory
   __shared__ DatasetT s_X;
   if (threadIdx.x == 0) {
     s_X = X;
   }
   __syncthreads();
-  __shared__ PathElement s_elements[kBlockSize];
-  PathElement* e = &s_elements[threadIdx.x];
+  __shared__ PathElement<SplitConditionT> s_elements[kBlockSize];
+  PathElement<SplitConditionT>* e = &s_elements[threadIdx.x];
 
   size_t start_row, end_row;
   bool thread_active;
@@ -615,13 +647,13 @@ __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
       float reduce =
           labelled_group.reduce(reduce_input, thrust::multiplies<float>());
       if (labelled_group.thread_rank() == condition_rank) {
+        float one_fraction = e->split_condition.EvaluateSplit(
+            X.GetElement(row_idx, e->feature_idx));
         auto phi_offset =
             IndexPhiInteractions(row_idx, num_groups, e->group, X.NumCols(),
                                  e->feature_idx, e->feature_idx);
-        atomicAddDouble(
-            phis_interactions + phi_offset,
-            reduce * (GetOneFraction(*e, X, row_idx) - e->zero_fraction) *
-                e->v);
+        atomicAddDouble(phis_interactions + phi_offset,
+                        reduce * (one_fraction - e->zero_fraction) * e->v);
       }
 
       int64_t condition_feature =
@@ -641,11 +673,13 @@ __global__ void __launch_bounds__(GPUTREESHAP_MAX_THREADS_PER_BLOCK)
   }
 }
 
-template <typename DatasetT, typename SizeTAllocatorT, typename PathAllocatorT>
+template <typename DatasetT, typename SizeTAllocatorT, typename PathAllocatorT,
+          typename SplitConditionT>
 void ComputeShapTaylorInteractions(
     DatasetT X,
     const thrust::device_vector<size_t, SizeTAllocatorT>& bin_segments,
-    const thrust::device_vector<PathElement, PathAllocatorT>& path_elements,
+    const thrust::device_vector<PathElement<SplitConditionT>, PathAllocatorT>&
+        path_elements,
     size_t num_groups, double* phis) {
   size_t bins_per_row = bin_segments.size() - 1;
   const int kBlockThreads = GPUTREESHAP_MAX_THREADS_PER_BLOCK;
@@ -663,7 +697,7 @@ void ComputeShapTaylorInteractions(
 
 template <typename PathVectorT, typename SizeVectorT, typename DeviceAllocatorT>
 void GetBinSegments(const PathVectorT& paths, const SizeVectorT& bin_map,
-                          SizeVectorT* bin_segments) {
+                    SizeVectorT* bin_segments) {
   DeviceAllocatorT alloc;
   size_t num_bins =
       thrust::reduce(thrust::cuda::par(alloc), bin_map.begin(), bin_map.end(),
@@ -685,18 +719,23 @@ void GetBinSegments(const PathVectorT& paths, const SizeVectorT& bin_map,
 }
 
 struct DeduplicateKeyTransformOp {
-  __device__ thrust::pair<size_t, int64_t> operator()(const PathElement& e) {
+  template <typename SplitConditionT>
+  __device__ thrust::pair<size_t, int64_t> operator()(
+      const PathElement<SplitConditionT>& e) {
     return {e.path_idx, e.feature_idx};
   }
 };
-template <typename PathVectorT, typename DeviceAllocatorT>
+
+template <typename PathVectorT, typename DeviceAllocatorT,
+          typename SplitConditionT>
 void DeduplicatePaths(PathVectorT* device_paths,
                       PathVectorT* deduplicated_paths) {
   DeviceAllocatorT alloc;
   // Sort by feature
   thrust::sort(thrust::cuda::par(alloc), device_paths->begin(),
                device_paths->end(),
-               [=] __device__(const PathElement& a, const PathElement& b) {
+               [=] __device__(const PathElement<SplitConditionT>& a,
+                              const PathElement<SplitConditionT>& b) {
                  if (a.path_idx < b.path_idx) return true;
                  if (b.path_idx < a.path_idx) return false;
 
@@ -714,13 +753,10 @@ void DeduplicatePaths(PathVectorT* device_paths,
       thrust::cuda::par(alloc), key_transform,
       key_transform + device_paths->size(), device_paths->begin(),
       thrust::make_discard_iterator(), deduplicated_paths->begin(), key_compare,
-      [=] __device__(PathElement a, const PathElement& b) {
+      [=] __device__(PathElement<SplitConditionT> a,
+                     const PathElement<SplitConditionT>& b) {
         // Combine duplicate features
-        a.feature_lower_bound =
-            max(a.feature_lower_bound, b.feature_lower_bound);
-        a.feature_upper_bound =
-            min(a.feature_upper_bound, b.feature_upper_bound);
-        a.is_missing_branch = a.is_missing_branch && b.is_missing_branch;
+        a.split_condition.Merge(b.split_condition);
         a.zero_fraction *= b.zero_fraction;
         return a;
       });
@@ -728,13 +764,14 @@ void DeduplicatePaths(PathVectorT* device_paths,
   deduplicated_paths->resize(end.second - deduplicated_paths->begin());
 }
 
-
-template <typename PathVectorT, typename SizeVectorT, typename DeviceAllocatorT>
+template <typename PathVectorT, typename SplitConditionT, typename SizeVectorT,
+          typename DeviceAllocatorT>
 void SortPaths(PathVectorT* paths, const SizeVectorT& bin_map) {
   auto d_bin_map = bin_map.data();
   DeviceAllocatorT alloc;
   thrust::sort(thrust::cuda::par(alloc), paths->begin(), paths->end(),
-               [=] __device__(const PathElement& a, const PathElement& b) {
+               [=] __device__(const PathElement<SplitConditionT>& a,
+                              const PathElement<SplitConditionT>& b) {
                  size_t a_bin = d_bin_map[a.path_idx];
                  size_t b_bin = d_bin_map[b.path_idx];
                  if (a_bin < b_bin) return true;
@@ -763,8 +800,8 @@ struct BFDCompare {
 // Best Fit Decreasing bin packing
 // Efficient O(nlogn) implementation with balanced tree using std::set
 template <typename IntVectorT>
-std::vector<size_t> BFDBinPacking(
-    const IntVectorT& counts, int bin_limit = 32) {
+std::vector<size_t> BFDBinPacking(const IntVectorT& counts,
+                                  int bin_limit = 32) {
   thrust::host_vector<int> counts_host(counts);
   std::vector<kv> path_lengths(counts_host.size());
   for (auto i = 0ull; i < counts_host.size(); i++) {
@@ -804,18 +841,18 @@ std::vector<size_t> BFDBinPacking(
 // First Fit Decreasing bin packing
 // Inefficient O(n^2) implementation
 template <typename IntVectorT>
-std::vector<size_t> FFDBinPacking(
-  const IntVectorT& counts, int bin_limit = 32) {
+std::vector<size_t> FFDBinPacking(const IntVectorT& counts,
+                                  int bin_limit = 32) {
   thrust::host_vector<int> counts_host(counts);
   std::vector<kv> path_lengths(counts_host.size());
   for (auto i = 0ull; i < counts_host.size(); i++) {
     path_lengths[i] = {i, counts_host[i]};
   }
   std::sort(path_lengths.begin(), path_lengths.end(),
-    [&](const kv& a, const kv& b) {
-    std::greater<> op;
-    return op(a.second, b.second);
-  });
+            [&](const kv& a, const kv& b) {
+              std::greater<> op;
+              return op(a.second, b.second);
+            });
 
   // map unique_id -> bin
   std::vector<size_t> bin_map(counts_host.size());
@@ -839,8 +876,7 @@ std::vector<size_t> FFDBinPacking(
 // Next Fit bin packing
 // O(n) implementation
 template <typename IntVectorT>
-std::vector<size_t> NFBinPacking(
-    const IntVectorT& counts, int bin_limit = 32) {
+std::vector<size_t> NFBinPacking(const IntVectorT& counts, int bin_limit = 32) {
   thrust::host_vector<int> counts_host(counts);
   std::vector<size_t> bin_map(counts_host.size());
   size_t current_bin = 0;
@@ -859,12 +895,14 @@ std::vector<size_t> NFBinPacking(
   return bin_map;
 }
 
-template <typename DeviceAllocatorT, typename PathVectorT,
-          typename LengthVectorT>
+template <typename DeviceAllocatorT, typename SplitConditionT,
+          typename PathVectorT, typename LengthVectorT>
 void GetPathLengths(const PathVectorT& device_paths,
-                          LengthVectorT* path_lengths) {
-  path_lengths->resize(static_cast<PathElement>(device_paths.back()).path_idx +
-                       1, 0);
+                    LengthVectorT* path_lengths) {
+  path_lengths->resize(
+      static_cast<PathElement<SplitConditionT>>(device_paths.back()).path_idx +
+          1,
+      0);
   auto counting = thrust::make_counting_iterator(0llu);
   auto d_paths = device_paths.data().get();
   auto d_lengths = path_lengths->data().get();
@@ -878,8 +916,9 @@ struct PathTooLongOp {
   __device__ size_t operator()(size_t length) { return length > 32; }
 };
 
+template <typename SplitConditionT>
 struct IncorrectVOp {
-  const PathElement* paths;
+  const PathElement<SplitConditionT>* paths;
   __device__ size_t operator()(size_t idx) {
     auto a = paths[idx - 1];
     auto b = paths[idx];
@@ -887,8 +926,8 @@ struct IncorrectVOp {
   }
 };
 
-template <typename DeviceAllocatorT, typename PathVectorT,
-          typename LengthVectorT>
+template <typename DeviceAllocatorT, typename SplitConditionT,
+          typename PathVectorT, typename LengthVectorT>
 void ValidatePaths(const PathVectorT& device_paths,
                    const LengthVectorT& path_lengths) {
   DeviceAllocatorT alloc;
@@ -901,7 +940,7 @@ void ValidatePaths(const PathVectorT& device_paths,
     throw std::invalid_argument("Tree depth must be <= 32");
   }
 
-  IncorrectVOp incorrect_v_op{device_paths.data().get()};
+  IncorrectVOp<SplitConditionT> incorrect_v_op{device_paths.data().get()};
   auto counting = thrust::counting_iterator<size_t>(0);
   auto incorrect_v =
       thrust::any_of(thrust::cuda::par(alloc), counting + 1,
@@ -913,33 +952,43 @@ void ValidatePaths(const PathVectorT& device_paths,
   }
 }
 
-template <typename DeviceAllocatorT, typename PathVectorT, typename SizeVectorT>
+template <typename DeviceAllocatorT, typename SplitConditionT,
+          typename PathVectorT, typename SizeVectorT>
 void PreprocessPaths(PathVectorT* device_paths, PathVectorT* deduplicated_paths,
                      SizeVectorT* bin_segments) {
   // Sort paths by length and feature
-  detail::DeduplicatePaths<PathVectorT, DeviceAllocatorT>(device_paths,
-                                                          deduplicated_paths);
+  detail::DeduplicatePaths<PathVectorT, DeviceAllocatorT, SplitConditionT>(
+      device_paths, deduplicated_paths);
   using int_vector = RebindVector<int, DeviceAllocatorT>;
   int_vector path_lengths;
-  detail::GetPathLengths<DeviceAllocatorT>(*deduplicated_paths, &path_lengths);
+  detail::GetPathLengths<DeviceAllocatorT, SplitConditionT>(*deduplicated_paths,
+                                                            &path_lengths);
   SizeVectorT device_bin_map = detail::BFDBinPacking(path_lengths);
-  ValidatePaths<DeviceAllocatorT>(*deduplicated_paths, path_lengths);
-  detail::SortPaths<PathVectorT, SizeVectorT, DeviceAllocatorT>(
-      deduplicated_paths, device_bin_map);
+  ValidatePaths<DeviceAllocatorT, SplitConditionT>(*deduplicated_paths,
+                                                   path_lengths);
+  detail::SortPaths<PathVectorT, SplitConditionT, SizeVectorT,
+                    DeviceAllocatorT>(deduplicated_paths, device_bin_map);
   detail::GetBinSegments<PathVectorT, SizeVectorT, DeviceAllocatorT>(
       *deduplicated_paths, device_bin_map, bin_segments);
 }
 
 struct PathIdxTransformOp {
-  __device__ size_t operator()(const PathElement& e) { return e.path_idx; }
+  template <typename SplitConditionT>
+  __device__ size_t operator()(const PathElement<SplitConditionT>& e) {
+    return e.path_idx;
+  }
 };
 
 struct GroupIdxTransformOp {
-  __device__ size_t operator()(const PathElement& e) { return e.group; }
+  template <typename SplitConditionT>
+  __device__ size_t operator()(const PathElement<SplitConditionT>& e) {
+    return e.group;
+  }
 };
 
 struct BiasTransformOp {
-  __device__ double operator()(const PathElement& e) {
+  template <typename SplitConditionT>
+  __device__ double operator()(const PathElement<SplitConditionT>& e) {
     return e.zero_fraction * e.v;
   }
 };
@@ -947,7 +996,7 @@ struct BiasTransformOp {
 // While it is possible to compute bias in the primary kernel, we do it here
 // using double precision to avoid numerical stability issues
 template <typename PathVectorT, typename DoubleVectorT,
-          typename DeviceAllocatorT>
+          typename DeviceAllocatorT, typename SplitConditionT>
 void ComputeBias(const PathVectorT& device_paths, DoubleVectorT* bias) {
   using double_vector = thrust::device_vector<
       double, typename DeviceAllocatorT::template rebind<double>::other>;
@@ -956,7 +1005,8 @@ void ComputeBias(const PathVectorT& device_paths, DoubleVectorT* bias) {
   // Make sure groups are contiguous
   thrust::sort(thrust::cuda::par(alloc), sorted_paths.begin(),
                sorted_paths.end(),
-               [=] __device__(const PathElement& a, const PathElement& b) {
+               [=] __device__(const PathElement<SplitConditionT>& a,
+                              const PathElement<SplitConditionT>& b) {
                  if (a.group < b.group) return true;
                  if (b.group < a.group) return false;
 
@@ -973,7 +1023,8 @@ void ComputeBias(const PathVectorT& device_paths, DoubleVectorT* bias) {
       thrust::cuda ::par(alloc), path_key, path_key + sorted_paths.size(),
       sorted_paths.begin(), thrust::make_discard_iterator(), combined.begin(),
       thrust::equal_to<size_t>(),
-      [=] __device__(PathElement a, const PathElement& b) {
+      [=] __device__(PathElement<SplitConditionT> a,
+                     const PathElement<SplitConditionT>& b) {
         a.zero_fraction *= b.zero_fraction;
         return a;
       });
@@ -1006,34 +1057,33 @@ void ComputeBias(const PathVectorT& device_paths, DoubleVectorT* bias) {
 };  // namespace detail
 
 /*!
- * Compute feature contributions on the GPU given a set of unique paths through a tree ensemble
- * and a dataset. Uses device memory proportional to the tree ensemble size.
+ * Compute feature contributions on the GPU given a set of unique paths through
+ * a tree ensemble and a dataset. Uses device memory proportional to the tree
+ * ensemble size.
  *
- * \exception std::invalid_argument Thrown when an invalid argument error condition occurs.
- * \tparam  PathIteratorT     Thrust type iterator, may be thrust::device_ptr for device memory, or
- *                            stl iterator/raw pointer for host memory.
- * \tparam  PhiIteratorT      Thrust type iterator, may be thrust::device_ptr for device memory, or
- *                            stl
- *                             iterator/raw pointer for host memory. Value type must be floating
- *                             point.
- * \tparam  DatasetT          User-specified dataset container.
- * \tparam  DeviceAllocatorT  Optional thrust style allocator.
+ * \exception std::invalid_argument Thrown when an invalid argument error
+ * condition occurs. \tparam  PathIteratorT     Thrust type iterator, may be
+ * thrust::device_ptr for device memory, or stl iterator/raw pointer for host
+ * memory. \tparam  PhiIteratorT      Thrust type iterator, may be
+ * thrust::device_ptr for device memory, or stl iterator/raw pointer for host
+ * memory. Value type must be floating point. \tparam  DatasetT User-specified
+ * dataset container. \tparam  DeviceAllocatorT  Optional thrust style
+ * allocator.
  *
- * \param X           Thin wrapper over a dataset allocated in device memory. X should be trivially
- *                    copyable as a kernel parameter (i.e. contain only pointers to actual data) and
- *                    must implement the methods NumRows()/NumCols()/GetElement(size_t row_idx,
- *                    size_t col_idx) as __device__ functions. GetElement may return NaN where the
- *                    feature value is missing.
+ * \param X           Thin wrapper over a dataset allocated in device memory. X
+ * should be trivially copyable as a kernel parameter (i.e. contain only
+ * pointers to actual data) and must implement the methods
+ * NumRows()/NumCols()/GetElement(size_t row_idx, size_t col_idx) as __device__
+ * functions. GetElement may return NaN where the feature value is missing.
  * \param begin       Iterator to paths, where separate paths are delineated by
- *                    PathElement.path_idx. Each unique path should contain 1 root with feature_idx =
- *                    -1 and zero_fraction = 1.0. The ordering of path elements inside a unique path
- *                    does not matter - the result will be the same. Paths may contain duplicate
- *                    features. See the PathElement class for more information.
- * \param end         Path end iterator.
- * \param num_groups  Number of output groups. In multiclass classification the algorithm outputs
- *                    feature contributions per output class.
- * \param phis_begin  Begin iterator for output phis.
- * \param phis_end    End iterator for output phis.
+ *                    PathElement.path_idx. Each unique path should contain 1
+ * root with feature_idx = -1 and zero_fraction = 1.0. The ordering of path
+ * elements inside a unique path does not matter - the result will be the same.
+ * Paths may contain duplicate features. See the PathElement class for more
+ * information. \param end         Path end iterator. \param num_groups  Number
+ * of output groups. In multiclass classification the algorithm outputs feature
+ * contributions per output class. \param phis_begin  Begin iterator for output
+ * phis. \param phis_end    End iterator for output phis.
  */
 template <typename DeviceAllocatorT = thrust::device_allocator<int>,
           typename DatasetT, typename PathIteratorT, typename PhiIteratorT>
@@ -1050,14 +1100,18 @@ void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
 
   using size_vector = detail::RebindVector<size_t, DeviceAllocatorT>;
   using double_vector = detail::RebindVector<double, DeviceAllocatorT>;
-  using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
+  using path_vector = detail::RebindVector<
+      typename std::iterator_traits<PathIteratorT>::value_type,
+      DeviceAllocatorT>;
+  using split_condition =
+      typename std::iterator_traits<PathIteratorT>::value_type::split_type;
 
   // Compute the global bias
   double_vector temp_phi(phis_end - phis_begin, 0.0);
   path_vector device_paths(begin, end);
   double_vector bias(num_groups, 0.0);
-  detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT>(
-      device_paths, &bias);
+  detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT,
+                      split_condition>(device_paths, &bias);
   auto d_bias = bias.data().get();
   auto d_temp_phi = temp_phi.data().get();
   thrust::for_each_n(thrust::make_counting_iterator(0llu),
@@ -1065,50 +1119,48 @@ void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
                        size_t group = idx % num_groups;
                        size_t row_idx = idx / num_groups;
                        d_temp_phi[IndexPhi(row_idx, num_groups, group,
-                                         X.NumCols(), X.NumCols())] +=
+                                           X.NumCols(), X.NumCols())] +=
                            d_bias[group];
                      });
 
   path_vector deduplicated_paths;
   size_vector device_bin_segments;
-  detail::PreprocessPaths<DeviceAllocatorT>(&device_paths, &deduplicated_paths,
-                                            &device_bin_segments);
+  detail::PreprocessPaths<DeviceAllocatorT, split_condition>(
+      &device_paths, &deduplicated_paths, &device_bin_segments);
 
   detail::ComputeShap(X, device_bin_segments, deduplicated_paths, num_groups,
                       temp_phi.data().get());
-  thrust::copy(temp_phi.begin(), temp_phi.end(),
-               phis_begin);
+  thrust::copy(temp_phi.begin(), temp_phi.end(), phis_begin);
 }
 
 /*!
- * Compute feature interaction contributions on the GPU given a set of unique paths through a tree
- * ensemble and a dataset. Uses device memory proportional to the tree ensemble size.
+ * Compute feature interaction contributions on the GPU given a set of unique
+ * paths through a tree ensemble and a dataset. Uses device memory proportional
+ * to the tree ensemble size.
  *
- * \exception std::invalid_argument Thrown when an invalid argument error condition occurs.
- * \tparam  PhiIteratorT      Thrust type iterator, may be thrust::device_ptr for device memory, or
- *                            stl
- *                             iterator/raw pointer for host memory. Value type must be floating
- *                             point.
- * \tparam  PathIteratorT     Thrust type iterator, may be thrust::device_ptr for device memory, or
- *                            stl iterator/raw pointer for host memory.
- * \tparam  DatasetT          User-specified dataset container.
- * \tparam  DeviceAllocatorT  Optional thrust style allocator.
+ * \exception std::invalid_argument Thrown when an invalid argument error
+ * condition occurs. \tparam  PhiIteratorT      Thrust type iterator, may be
+ * thrust::device_ptr for device memory, or stl iterator/raw pointer for host
+ * memory. Value type must be floating point. \tparam  PathIteratorT     Thrust
+ * type iterator, may be thrust::device_ptr for device memory, or stl
+ * iterator/raw pointer for host memory. \tparam  DatasetT User-specified
+ * dataset container. \tparam  DeviceAllocatorT  Optional thrust style
+ * allocator.
  *
- * \param X           Thin wrapper over a dataset allocated in device memory. X should be trivially
- *                    copyable as a kernel parameter (i.e. contain only pointers to actual data) and
- *                    must implement the methods NumRows()/NumCols()/GetElement(size_t row_idx,
- *                    size_t col_idx) as __device__ functions. GetElement may return NaN where the
- *                    feature value is missing.
+ * \param X           Thin wrapper over a dataset allocated in device memory. X
+ * should be trivially copyable as a kernel parameter (i.e. contain only
+ * pointers to actual data) and must implement the methods
+ * NumRows()/NumCols()/GetElement(size_t row_idx, size_t col_idx) as __device__
+ * functions. GetElement may return NaN where the feature value is missing.
  * \param begin       Iterator to paths, where separate paths are delineated by
- *                    PathElement.path_idx. Each unique path should contain 1 root with feature_idx =
- *                    -1 and zero_fraction = 1.0. The ordering of path elements inside a unique path
- *                    does not matter - the result will be the same. Paths may contain duplicate
- *                    features. See the PathElement class for more information.
- * \param end         Path end iterator.
- * \param num_groups  Number of output groups. In multiclass classification the algorithm outputs
- *                    feature contributions per output class.
- * \param phis_begin  Begin iterator for output phis.
- * \param phis_end    End iterator for output phis.
+ *                    PathElement.path_idx. Each unique path should contain 1
+ * root with feature_idx = -1 and zero_fraction = 1.0. The ordering of path
+ * elements inside a unique path does not matter - the result will be the same.
+ * Paths may contain duplicate features. See the PathElement class for more
+ * information. \param end         Path end iterator. \param num_groups  Number
+ * of output groups. In multiclass classification the algorithm outputs feature
+ * contributions per output class. \param phis_begin  Begin iterator for output
+ * phis. \param phis_end    End iterator for output phis.
  */
 template <typename DeviceAllocatorT = thrust::device_allocator<int>,
           typename DatasetT, typename PathIteratorT, typename PhiIteratorT>
@@ -1126,14 +1178,18 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
 
   using size_vector = detail::RebindVector<size_t, DeviceAllocatorT>;
   using double_vector = detail::RebindVector<double, DeviceAllocatorT>;
-  using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
+  using path_vector = detail::RebindVector<
+      typename std::iterator_traits<PathIteratorT>::value_type,
+      DeviceAllocatorT>;
+  using split_condition =
+      typename std::iterator_traits<PathIteratorT>::value_type::split_type;
 
   // Compute the global bias
-  double_vector temp_phi(phis_end - phis_begin , 0.0);
+  double_vector temp_phi(phis_end - phis_begin, 0.0);
   path_vector device_paths(begin, end);
   double_vector bias(num_groups, 0.0);
-  detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT>(
-      device_paths, &bias);
+  detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT,
+                      split_condition>(device_paths, &bias);
   auto d_bias = bias.data().get();
   auto d_temp_phi = temp_phi.data().get();
   thrust::for_each_n(
@@ -1148,8 +1204,8 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
 
   path_vector deduplicated_paths;
   size_vector device_bin_segments;
-  detail::PreprocessPaths<DeviceAllocatorT>(&device_paths, &deduplicated_paths,
-                                            &device_bin_segments);
+  detail::PreprocessPaths<DeviceAllocatorT, split_condition>(
+      &device_paths, &deduplicated_paths, &device_bin_segments);
 
   detail::ComputeShapInteractions(X, device_bin_segments, deduplicated_paths,
                                   num_groups, temp_phi.data().get());
@@ -1157,33 +1213,33 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
 }
 
 /*!
- * Compute feature interaction contributions using the Shapley Taylor index on the GPU, given a
- * set of unique paths through a tree ensemble and a dataset. Uses device memory proportional to
- * the tree ensemble size.
+ * Compute feature interaction contributions using the Shapley Taylor index on
+ * the GPU, given a set of unique paths through a tree ensemble and a dataset.
+ * Uses device memory proportional to the tree ensemble size.
  *
- * \exception std::invalid_argument Thrown when an invalid argument error condition occurs.
- * \tparam  DeviceAllocatorT  Optional thrust style allocator.
+ * \exception std::invalid_argument Thrown when an invalid argument error
+ * condition occurs. \tparam  DeviceAllocatorT  Optional thrust style allocator.
  * \tparam  DatasetT      User-specified dataset container.
- * \tparam  PathIteratorT Thrust type iterator, may be thrust::device_ptr for device memory, or stl
- *                        iterator/raw pointer for host memory.
- * \tparam  PhiIteratorT Thrust type iterator, may be thrust::device_ptr for device memory, or stl
- *                        iterator/raw pointer for host memory. Value type must be floating point.
+ * \tparam  PathIteratorT Thrust type iterator, may be thrust::device_ptr for
+ * device memory, or stl iterator/raw pointer for host memory. \tparam
+ * PhiIteratorT Thrust type iterator, may be thrust::device_ptr for device
+ * memory, or stl iterator/raw pointer for host memory. Value type must be
+ * floating point.
  *
- * \param X           Thin wrapper over a dataset allocated in device memory. X should be trivially
- *                    copyable as a kernel parameter (i.e. contain only pointers to actual data) and
- *                    must implement the methods NumRows()/NumCols()/GetElement(size_t row_idx,
- *                    size_t col_idx) as __device__ functions. GetElement may return NaN where the
- *                    feature value is missing.
+ * \param X           Thin wrapper over a dataset allocated in device memory. X
+ * should be trivially copyable as a kernel parameter (i.e. contain only
+ * pointers to actual data) and must implement the methods
+ * NumRows()/NumCols()/GetElement(size_t row_idx, size_t col_idx) as __device__
+ * functions. GetElement may return NaN where the feature value is missing.
  * \param begin       Iterator to paths, where separate paths are delineated by
- *                    PathElement.path_idx. Each unique path should contain 1 root with feature_idx =
- *                    -1 and zero_fraction = 1.0. The ordering of path elements inside a unique path
- *                    does not matter - the result will be the same. Paths may contain duplicate
- *                    features. See the PathElement class for more information.
- * \param end         Path end iterator.
- * \param num_groups  Number of output groups. In multiclass classification the algorithm outputs
- *                    feature contributions per output class.
- * \param phis_begin  Begin iterator for output phis.
- * \param phis_end    End iterator for output phis.
+ *                    PathElement.path_idx. Each unique path should contain 1
+ * root with feature_idx = -1 and zero_fraction = 1.0. The ordering of path
+ * elements inside a unique path does not matter - the result will be the same.
+ * Paths may contain duplicate features. See the PathElement class for more
+ * information. \param end         Path end iterator. \param num_groups  Number
+ * of output groups. In multiclass classification the algorithm outputs feature
+ * contributions per output class. \param phis_begin  Begin iterator for output
+ * phis. \param phis_end    End iterator for output phis.
  */
 template <typename DeviceAllocatorT = thrust::device_allocator<int>,
           typename DatasetT, typename PathIteratorT, typename PhiIteratorT>
@@ -1207,14 +1263,18 @@ void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
 
   using size_vector = detail::RebindVector<size_t, DeviceAllocatorT>;
   using double_vector = detail::RebindVector<double, DeviceAllocatorT>;
-  using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
+  using path_vector = detail::RebindVector<
+      typename std::iterator_traits<PathIteratorT>::value_type,
+      DeviceAllocatorT>;
+  using split_condition =
+      typename std::iterator_traits<PathIteratorT>::value_type::split_type;
 
   // Compute the global bias
   double_vector temp_phi(phis_end - phis_begin, 0.0);
   path_vector device_paths(begin, end);
   double_vector bias(num_groups, 0.0);
-  detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT>(
-      device_paths, &bias);
+  detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT,
+                      split_condition>(device_paths, &bias);
   auto d_bias = bias.data().get();
   auto d_temp_phi = temp_phi.data().get();
   thrust::for_each_n(
@@ -1229,8 +1289,8 @@ void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
 
   path_vector deduplicated_paths;
   size_vector device_bin_segments;
-  detail::PreprocessPaths<DeviceAllocatorT>(&device_paths, &deduplicated_paths,
-                                            &device_bin_segments);
+  detail::PreprocessPaths<DeviceAllocatorT, split_condition>(
+      &device_paths, &deduplicated_paths, &device_bin_segments);
 
   detail::ComputeShapTaylorInteractions(X, device_bin_segments,
                                         deduplicated_paths, num_groups,

--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -977,44 +977,40 @@ void ComputeBias(const PathVectorT& device_paths, DoubleVectorT* bias) {
  * Compute feature contributions on the GPU given a set of unique paths through a tree ensemble
  * and a dataset. Uses device memory proportional to the tree ensemble size.
  *
+ * \exception std::invalid_argument Thrown when an invalid argument error condition occurs.
+ * \tparam  PathIteratorT     Thrust type iterator, may be thrust::device_ptr for device memory, or
+ *                            stl iterator/raw pointer for host memory.
+ * \tparam  PhiIteratorT      Thrust type iterator, may be thrust::device_ptr for device memory, or
+ *                            stl
+ *                             iterator/raw pointer for host memory. Value type must be floating
+ *                             point.
+ * \tparam  DatasetT          User-specified dataset container.
  * \tparam  DeviceAllocatorT  Optional thrust style allocator.
  *
- * \param           X               Thin wrapper over a dataset allocated in device memory. X
- *                                  should be trivially copyable as a kernel parameter (i.e.
- *                                  contain only pointers to actual data) and must implement the
- *                                  methods NumRows()/NumCols()/GetElement(size_t row_idx, size_t
- *                                  col_idx) as __device__ functions. GetElement may return NaN
- *                                  where the feature value is missing.
- * \param           begin           Iterator to paths, where separate paths are delineated by
- *                                  PathElement.path_idx. Each unique path should contain 1 root
- *                                  with feature_idx = -1 and zero_fraction = 1.0. The ordering of
- *                                  path elements inside a unique path does not matter - the result
- *                                  will be the same. Paths may contain duplicate features. See the
- *                                  PathElement class for more information.
- * \param           end             Path end iterator.
- * \param           num_groups      Number of output groups. In multiclass classification the
- *                                  algorithm outputs feature contributions per output class.
- * \param [in,out]  phis_out        Device memory buffer for returning the feature contributions.
- *                                  The last feature column contains the bias term. Feature
- *                                  contributions can be retrieved by phis_out[(row_idx *
- *                                  num_groups + group) * (X.NumCols() + 1) + feature_idx]. Results
- *                                  are added to the input buffer without zeroing memory - do not
- *                                  pass uninitialised memory.
- * \param           phis_out_length Length of the phis_out for bounds checking. Must be at least of
- *                                  size X.NumRows() * (X.NumCols() + 1) * num_groups.
- *
- * \tparam  DatasetT  User-specified dataset container.
- *
- * \tparam  PathIteratorT Thrust type iterator, may be thrust::device_ptr for device memory, or stl
- *                        iterator/raw pointer for host memory.
+ * \param X           Thin wrapper over a dataset allocated in device memory. X should be trivially
+ *                    copyable as a kernel parameter (i.e. contain only pointers to actual data) and
+ *                    must implement the methods NumRows()/NumCols()/GetElement(size_t row_idx,
+ *                    size_t col_idx) as __device__ functions. GetElement may return NaN where the
+ *                    feature value is missing.
+ * \param begin       Iterator to paths, where separate paths are delineated by
+ *                    PathElement.path_idx. Each unique path should contain 1 root with feature_idx =
+ *                    -1 and zero_fraction = 1.0. The ordering of path elements inside a unique path
+ *                    does not matter - the result will be the same. Paths may contain duplicate
+ *                    features. See the PathElement class for more information.
+ * \param end         Path end iterator.
+ * \param num_groups  Number of output groups. In multiclass classification the algorithm outputs
+ *                    feature contributions per output class.
+ * \param phis_begin  Begin iterator for output phis.
+ * \param phis_end    End iterator for output phis.
  */
 template <typename DeviceAllocatorT = thrust::device_allocator<int>,
-          typename DatasetT, typename PathIteratorT>
+          typename DatasetT, typename PathIteratorT, typename PhiIteratorT>
 void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
-                 size_t num_groups, float* phis_out, size_t phis_out_length) {
+                 size_t num_groups, PhiIteratorT phis_begin,
+                 PhiIteratorT phis_end) {
   if (X.NumRows() == 0 || X.NumCols() == 0 || end - begin <= 0) return;
 
-  if (phis_out_length < X.NumRows() * (X.NumCols() + 1) * num_groups) {
+  if (phis_end - phis_begin < X.NumRows() * (X.NumCols() + 1) * num_groups) {
     throw std::invalid_argument(
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1) * "
         "num_groups");
@@ -1025,7 +1021,7 @@ void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
   using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
 
   // Compute the global bias
-  double_vector temp_phi(phis_out_length, 0.0);
+  double_vector temp_phi(phis_end - phis_begin, 0.0);
   path_vector device_paths(begin, end);
   double_vector bias(num_groups, 0.0);
   detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT>(
@@ -1049,48 +1045,46 @@ void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
   detail::ComputeShap(X, device_bin_segments, deduplicated_paths, num_groups,
                       temp_phi.data().get());
   thrust::copy(temp_phi.begin(), temp_phi.end(),
-               thrust::device_pointer_cast(phis_out));
+               phis_begin);
 }
 
 /*!
  * Compute feature interaction contributions on the GPU given a set of unique paths through a tree
  * ensemble and a dataset. Uses device memory proportional to the tree ensemble size.
  *
- * \tparam  DatasetT  User-specified dataset container.
+ * \exception std::invalid_argument Thrown when an invalid argument error condition occurs.
+ * \tparam  PhiIteratorT      Thrust type iterator, may be thrust::device_ptr for device memory, or
+ *                            stl
+ *                             iterator/raw pointer for host memory. Value type must be floating
+ *                             point.
+ * \tparam  PathIteratorT     Thrust type iterator, may be thrust::device_ptr for device memory, or
+ *                            stl iterator/raw pointer for host memory.
+ * \tparam  DatasetT          User-specified dataset container.
+ * \tparam  DeviceAllocatorT  Optional thrust style allocator.
  *
- * \param           X               Thin wrapper over a dataset allocated in device memory. X
- *                                  should be trivially copyable as a kernel parameter (i.e.
- *                                  contain only pointers to actual data) and must implement the
- *                                  methods NumRows()/NumCols()/GetElement(size_t row_idx, size_t
- *                                  col_idx) as __device__ functions. GetElement may return NaN
- *                                  where the feature value is missing.
- * \param           begin           Iterator to paths, where separate paths are delineated by
- *                                  PathElement.path_idx. Each unique path should contain 1 root
- *                                  with feature_idx = -1 and zero_fraction = 1.0. The ordering of
- *                                  path elements inside a unique path does not matter - the result
- *                                  will be the same. Paths may contain duplicate features. See the
- *                                  PathElement class for more information.
- * \param           end             Path end iterator.
- * \param           num_groups      Number of output groups. In multiclass classification the
- *                                  algorithm outputs feature contributions per output class.
- * \param [in,out]  phis_out        Device memory buffer for returning the feature interaction
- *                                  contributions.  The last feature column contains the bias term.
- *                                  Results are added to the input buffer without zeroing memory -
- *                                  do not pass uninitialised memory.
- * \param           phis_out_length Length of the phis_out for bounds checking. Must be at least
- *                                  size X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) *
- *                                  num_groups. *.
- *
- * \tparam  PathIteratorT Thrust type iterator, may be thrust::device_ptr for device memory, or stl
- *                        iterator/raw pointer for host memory.
+ * \param X           Thin wrapper over a dataset allocated in device memory. X should be trivially
+ *                    copyable as a kernel parameter (i.e. contain only pointers to actual data) and
+ *                    must implement the methods NumRows()/NumCols()/GetElement(size_t row_idx,
+ *                    size_t col_idx) as __device__ functions. GetElement may return NaN where the
+ *                    feature value is missing.
+ * \param begin       Iterator to paths, where separate paths are delineated by
+ *                    PathElement.path_idx. Each unique path should contain 1 root with feature_idx =
+ *                    -1 and zero_fraction = 1.0. The ordering of path elements inside a unique path
+ *                    does not matter - the result will be the same. Paths may contain duplicate
+ *                    features. See the PathElement class for more information.
+ * \param end         Path end iterator.
+ * \param num_groups  Number of output groups. In multiclass classification the algorithm outputs
+ *                    feature contributions per output class.
+ * \param phis_begin  Begin iterator for output phis.
+ * \param phis_end    End iterator for output phis.
  */
 template <typename DeviceAllocatorT = thrust::device_allocator<int>,
-          typename DatasetT, typename PathIteratorT>
+          typename DatasetT, typename PathIteratorT, typename PhiIteratorT>
 void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
-                             size_t num_groups, float* phis_out,
-                             size_t phis_out_length) {
+                             size_t num_groups, PhiIteratorT phis_begin,
+                             PhiIteratorT phis_end) {
   if (X.NumRows() == 0 || X.NumCols() == 0 || end - begin <= 0) return;
-  if (phis_out_length <
+  if (phis_end - phis_begin <
       X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) * num_groups) {
     throw std::invalid_argument(
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1)  * "
@@ -1103,7 +1097,7 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
   using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
 
   // Compute the global bias
-  double_vector temp_phi(phis_out_length, 0.0);
+  double_vector temp_phi(phis_end - phis_begin , 0.0);
   path_vector device_paths(begin, end);
   double_vector bias(num_groups, 0.0);
   detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT>(
@@ -1127,49 +1121,51 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
 
   detail::ComputeShapInteractions(X, device_bin_segments, deduplicated_paths,
                                   num_groups, temp_phi.data().get());
-  thrust::copy(temp_phi.begin(), temp_phi.end(),
-               thrust::device_pointer_cast(phis_out));
+  thrust::copy(temp_phi.begin(), temp_phi.end(), phis_begin);
 }
 
 /*!
- * Compute feature interaction contributions using the Shapley Taylor index on the GPU, given a set of unique paths through a tree
- * ensemble and a dataset. Uses device memory proportional to the tree ensemble size.
+ * Compute feature interaction contributions using the Shapley Taylor index on the GPU, given a
+ * set of unique paths through a tree ensemble and a dataset. Uses device memory proportional to
+ * the tree ensemble size.
  *
- * \tparam  DatasetT  User-specified dataset container.
- *
- * \param           X               Thin wrapper over a dataset allocated in device memory. X
- *                                  should be trivially copyable as a kernel parameter (i.e.
- *                                  contain only pointers to actual data) and must implement the
- *                                  methods NumRows()/NumCols()/GetElement(size_t row_idx, size_t
- *                                  col_idx) as __device__ functions. GetElement may return NaN
- *                                  where the feature value is missing.
- * \param           begin           Iterator to paths, where separate paths are delineated by
- *                                  PathElement.path_idx. Each unique path should contain 1 root
- *                                  with feature_idx = -1 and zero_fraction = 1.0. The ordering of
- *                                  path elements inside a unique path does not matter - the result
- *                                  will be the same. Paths may contain duplicate features. See the
- *                                  PathElement class for more information.
- * \param           end             Path end iterator.
- * \param           num_groups      Number of output groups. In multiclass classification the
- *                                  algorithm outputs feature contributions per output class.
- * \param [in,out]  phis_out        Device memory buffer for returning the feature interaction
- *                                  contributions.  The last feature column contains the bias term.
- *                                  Results are added to the input buffer without zeroing memory -
- *                                  do not pass uninitialised memory.
- * \param           phis_out_length Length of the phis_out for bounds checking. Must be at least
- *                                  size X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) *
- *                                  num_groups. *.
- *
+ * \exception std::invalid_argument Thrown when an invalid argument error condition occurs.
+ * \tparam  DeviceAllocatorT  Optional thrust style allocator.
+ * \tparam  DatasetT      User-specified dataset container.
  * \tparam  PathIteratorT Thrust type iterator, may be thrust::device_ptr for device memory, or stl
  *                        iterator/raw pointer for host memory.
+ * \tparam  PhiIteratorT Thrust type iterator, may be thrust::device_ptr for device memory, or stl
+ *                        iterator/raw pointer for host memory. Value type must be floating point.
+ *
+ * \param X           Thin wrapper over a dataset allocated in device memory. X should be trivially
+ *                    copyable as a kernel parameter (i.e. contain only pointers to actual data) and
+ *                    must implement the methods NumRows()/NumCols()/GetElement(size_t row_idx,
+ *                    size_t col_idx) as __device__ functions. GetElement may return NaN where the
+ *                    feature value is missing.
+ * \param begin       Iterator to paths, where separate paths are delineated by
+ *                    PathElement.path_idx. Each unique path should contain 1 root with feature_idx =
+ *                    -1 and zero_fraction = 1.0. The ordering of path elements inside a unique path
+ *                    does not matter - the result will be the same. Paths may contain duplicate
+ *                    features. See the PathElement class for more information.
+ * \param end         Path end iterator.
+ * \param num_groups  Number of output groups. In multiclass classification the algorithm outputs
+ *                    feature contributions per output class.
+ * \param phis_begin  Begin iterator for output phis.
+ * \param phis_end    End iterator for output phis.
  */
 template <typename DeviceAllocatorT = thrust::device_allocator<int>,
-          typename DatasetT, typename PathIteratorT>
+          typename DatasetT, typename PathIteratorT, typename PhiIteratorT>
 void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
                                    PathIteratorT end, size_t num_groups,
-                                   float* phis_out, size_t phis_out_length) {
+                                   PhiIteratorT phis_begin,
+                                   PhiIteratorT phis_end) {
+  using phis_type = typename std::iterator_traits<PhiIteratorT>::value_type;
+  static_assert(std::is_floating_point<phis_type>::value,
+                "Phis type must be floating point");
+
   if (X.NumRows() == 0 || X.NumCols() == 0 || end - begin <= 0) return;
-  if (phis_out_length <
+
+  if (phis_end - phis_begin <
       X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) * num_groups) {
     throw std::invalid_argument(
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1)  * "
@@ -1182,7 +1178,7 @@ void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
   using path_vector = detail::RebindVector<PathElement, DeviceAllocatorT>;
 
   // Compute the global bias
-  double_vector temp_phi(phis_out_length, 0.0);
+  double_vector temp_phi(phis_end - phis_begin, 0.0);
   path_vector device_paths(begin, end);
   double_vector bias(num_groups, 0.0);
   detail::ComputeBias<path_vector, double_vector, DeviceAllocatorT>(
@@ -1207,7 +1203,6 @@ void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
   detail::ComputeShapTaylorInteractions(X, device_bin_segments,
                                         deduplicated_paths, num_groups,
                                         temp_phi.data().get());
-  thrust::copy(temp_phi.begin(), temp_phi.end(),
-               thrust::device_pointer_cast(phis_out));
+  thrust::copy(temp_phi.begin(), temp_phi.end(), phis_begin);
 }
-};  // namespace gpu_treeshap
+}  // namespace gpu_treeshap

--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -1092,7 +1092,8 @@ void GPUTreeShap(DatasetT X, PathIteratorT begin, PathIteratorT end,
                  PhiIteratorT phis_end) {
   if (X.NumRows() == 0 || X.NumCols() == 0 || end - begin <= 0) return;
 
-  if (phis_end - phis_begin < X.NumRows() * (X.NumCols() + 1) * num_groups) {
+  if (size_t(phis_end - phis_begin) <
+      X.NumRows() * (X.NumCols() + 1) * num_groups) {
     throw std::invalid_argument(
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1) * "
         "num_groups");
@@ -1168,7 +1169,7 @@ void GPUTreeShapInteractions(DatasetT X, PathIteratorT begin, PathIteratorT end,
                              size_t num_groups, PhiIteratorT phis_begin,
                              PhiIteratorT phis_end) {
   if (X.NumRows() == 0 || X.NumCols() == 0 || end - begin <= 0) return;
-  if (phis_end - phis_begin <
+  if (size_t(phis_end - phis_begin) <
       X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) * num_groups) {
     throw std::invalid_argument(
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1)  * "
@@ -1253,7 +1254,7 @@ void GPUTreeShapTaylorInteractions(DatasetT X, PathIteratorT begin,
 
   if (X.NumRows() == 0 || X.NumCols() == 0 || end - begin <= 0) return;
 
-  if (phis_end - phis_begin <
+  if (size_t(phis_end - phis_begin) <
       X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) * num_groups) {
     throw std::invalid_argument(
         "phis_out must be at least of size X.NumRows() * (X.NumCols() + 1)  * "

--- a/benchmark/benchmark_gpu_treeshap.cu
+++ b/benchmark/benchmark_gpu_treeshap.cu
@@ -40,7 +40,7 @@ class Fixture : public benchmark::Fixture {
     phis.reset();
     test_data.reset();
   }
-  std::vector<PathElement> model;
+  std::vector<PathElement<XgboostSplitCondition>> model;
   std::unique_ptr<TestDataset> test_data;
   DenseDatasetWrapper X;
   std::unique_ptr<thrust::device_vector<float>> phis;
@@ -51,8 +51,8 @@ class Fixture : public benchmark::Fixture {
 
 BENCHMARK_DEFINE_F(Fixture, GPUTreeShap)(benchmark::State& st) { // NOLINT
   for (auto _ : st) {
-    GPUTreeShap(X, model.begin(), model.end(), num_groups, phis->data().get(),
-                phis->size());
+    GPUTreeShap(X, model.begin(), model.end(), num_groups, phis->begin(),
+                phis->end());
   }
 }
 BENCHMARK_REGISTER_F(Fixture, GPUTreeShap)
@@ -66,7 +66,7 @@ BENCHMARK_DEFINE_F(Fixture, GPUTreeShapInteractions)(benchmark::State& st) {// N
                                               (X.NumCols() + 1) * num_groups));
   for (auto _ : st) {
     GPUTreeShapInteractions(X, model.begin(), model.end(), num_groups,
-                            phis->data().get(), phis->size());
+                            phis->begin(), phis->end());
   }
 }
 
@@ -82,7 +82,7 @@ BENCHMARK_DEFINE_F(Fixture, GPUTreeShapTaylorInteractions)
                                               (X.NumCols() + 1) * num_groups));
   for (auto _ : st) {
     GPUTreeShapTaylorInteractions(X, model.begin(), model.end(), num_groups,
-                                  phis->data().get(), phis->size());
+                                  phis->begin(), phis->end());
   }
 }
 

--- a/example/example.cu
+++ b/example/example.cu
@@ -84,13 +84,40 @@ std::ostream& operator<<(std::ostream& os, const DecisionTree& dt) {
   return os;
 }
 
-std::vector<gpu_treeshap::PathElement> ExtractPaths(const DecisionTree& dt) {
-  std::vector<gpu_treeshap::PathElement> paths;
+// Define a custom split condition implementing EvaluateSplit and Merge
+struct MySplitCondition {
+  MySplitCondition() = default;
+  MySplitCondition(float feature_lower_bound, float feature_upper_bound)
+      : feature_lower_bound(feature_lower_bound),
+        feature_upper_bound(feature_upper_bound) {
+    assert(feature_lower_bound <= feature_upper_bound);
+  }
+
+  /*! Feature values >= lower and < upper flow down this path. */
+  float feature_lower_bound;
+  float feature_upper_bound;
+
+  // Does this instance flow down this path?
+  __host__ __device__ bool EvaluateSplit(float x) const {
+    return x >= feature_lower_bound && x < feature_upper_bound;
+  }
+
+  // Combine two split conditions on the same feature
+  __host__ __device__ void Merge(
+      const MySplitCondition& other) {  // Combine duplicate features
+    feature_lower_bound = max(feature_lower_bound, other.feature_lower_bound);
+    feature_upper_bound = min(feature_upper_bound, other.feature_upper_bound);
+  }
+};
+
+std::vector<gpu_treeshap::PathElement<MySplitCondition>> ExtractPaths(
+    const DecisionTree& dt) {
+  std::vector<gpu_treeshap::PathElement<MySplitCondition>> paths;
   size_t path_idx = 0;
   // Find leaf nodes
   // Work backwards from leaf to root, order does not matter
   // It's also possible to work from root to leaf
-  for (int i = 0; i <static_cast<int>(dt.nodes.size()); i++) {
+  for (int i = 0; i < static_cast<int>(dt.nodes.size()); i++) {
     if (dt.nodes[i].IsLeaf()) {
       auto child = dt.nodes[i];
       float v = child.leaf_value;
@@ -103,25 +130,30 @@ std::vector<gpu_treeshap::PathElement> ExtractPaths(const DecisionTree& dt) {
         bool is_left_path = parent.left_child == child_idx;
         float lower_bound = is_left_path ? -inf : parent.split_condition;
         float upper_bound = is_left_path ? parent.split_condition : inf;
-        paths.emplace_back(path_idx, parent.feature_idx, 0, lower_bound,
-                           upper_bound, false, zero_fraction, v);
+        paths.push_back({path_idx,
+                         parent.feature_idx,
+                         0,
+                         {lower_bound, upper_bound},
+                         zero_fraction,
+                         v});
         child_idx = child.parent;
         child = parent;
       }
       // Root node has feature -1
-      paths.emplace_back(path_idx, -1, 0, -inf, inf, false, 1.0, v);
+      paths.push_back({path_idx, -1, 0, {-inf, inf}, 1.0, v});
       path_idx++;
     }
   }
   return paths;
 }
 
-std::ostream& operator<<(std::ostream& os,
-                         const std::vector<gpu_treeshap::PathElement>& paths) {
-  std::vector<gpu_treeshap::PathElement> tmp(paths);
+std::ostream& operator<<(
+    std::ostream& os,
+    const std::vector<gpu_treeshap::PathElement<MySplitCondition>>& paths) {
+  std::vector<gpu_treeshap::PathElement<MySplitCondition>> tmp(paths);
   std::sort(tmp.begin(), tmp.end(),
-            [&](const gpu_treeshap::PathElement& a,
-                const gpu_treeshap::PathElement& b) {
+            [&](const gpu_treeshap::PathElement<MySplitCondition>& a,
+                const gpu_treeshap::PathElement<MySplitCondition>& b) {
               if (a.path_idx < b.path_idx) return true;
               if (b.path_idx < a.path_idx) return false;
 
@@ -137,7 +169,8 @@ std::ostream& operator<<(std::ostream& os,
       os << "\n";
     }
     os << " (feature:" << e.feature_idx << ", pz:" << e.zero_fraction << ", ["
-       << e.feature_lower_bound << "<=x<" << e.feature_upper_bound << "])";
+       << e.split_condition.feature_lower_bound << "<=x<"
+       << e.split_condition.feature_upper_bound << "])";
     os << "\n";
   }
   return os;
@@ -189,8 +222,8 @@ int main() {
   data[5] = 1.0;
   DenseDatasetWrapper X(data.data().get(), 2, 3);
   thrust::device_vector<float> phis((X.NumCols() + 1) * X.NumRows());
-  gpu_treeshap::GPUTreeShap(X, paths.begin(), paths.end(), 1,
-                            phis.data().get(), phis.size());
+  gpu_treeshap::GPUTreeShap(X, paths.begin(), paths.end(), 1, phis.begin(),
+                            phis.end());
 
   // Print the resulting feature contributions
   std::cout << "\n";

--- a/tests/test_gpu_treeshap.cu
+++ b/tests/test_gpu_treeshap.cu
@@ -194,8 +194,8 @@ class APITest : public ::testing::Test {
 TEST_F(APITest, PathTooLong) {
   model.resize(33);
   model[0] = {0, -1, 0, {0, 0, 0}, 0, 0};
-  for (int64_t i = 1; i < model.size(); i++) {
-    model[i] = {0, i, 0, {0, 0, 0}, 0, 0};
+  for (size_t i = 1; i < model.size(); i++) {
+    model[i] = {0, static_cast<int64_t>(i), 0, {0, 0, 0}, 0, 0};
   }
   ExpectAPIThrow<std::invalid_argument>("Tree depth must be <= 32");
 }

--- a/tests/test_gpu_treeshap.cu
+++ b/tests/test_gpu_treeshap.cu
@@ -43,7 +43,7 @@ class ParameterisedModelTest
     phis.resize(X.NumRows() * (X.NumCols() + 1) * (X.NumCols() + 1) *
                 num_groups);
   }
-  std::vector<PathElement> model;
+  std::vector<PathElement<XgboostSplitCondition>> model;
   TestDataset test_data;
   DenseDatasetWrapper X;
   std::vector<float> margin;
@@ -78,8 +78,7 @@ TEST_P(ParameterisedModelTest, ShapInteractionsSum) {
   GPUTreeShap(X, model.begin(), model.end(), num_groups, phis.begin(),
               phis.end());
   GPUTreeShapInteractions(X, model.begin(), model.end(), num_groups,
-                          phis_interactions.begin(),
-                          phis_interactions.end());
+                          phis_interactions.begin(), phis_interactions.end());
   thrust::host_vector<float> interactions_result(phis_interactions);
   std::vector<float> sum(phis.size());
   for (auto row_idx = 0ull; row_idx < num_rows; row_idx++) {
@@ -161,11 +160,11 @@ class APITest : public ::testing::Test {
   APITest() {
     const float inf = std::numeric_limits<float>::infinity();
     model = {
-        PathElement{0, -1, 0, -inf, inf, false, 1.0f, 2.0f},
-        {0, 0, 0, 0.5f, inf, false, 0.25f, 2.0f},
-        {0, 1, 0, 0.5f, inf, false, 0.5f, 2.0f},
-        {0, 2, 0, 0.5f, inf, false, 0.6f, 2.0f},
-        {0, 3, 0, 0.5f, inf, false, 1.0f, 2.0f},
+        {0, -1, 0, {-inf, inf, false}, 1.0f, 2.0f},
+        {0, 0, 0, {0.5f, inf, false}, 0.25f, 2.0f},
+        {0, 1, 0, {0.5f, inf, false}, 0.5f, 2.0f},
+        {0, 2, 0, {0.5f, inf, false}, 0.6f, 2.0f},
+        {0, 3, 0, {0.5f, inf, false}, 1.0f, 2.0f},
     };
     data = std::vector<float>({1.0f, 1.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f});
     X = DenseDatasetWrapper(data.data().get(), 2, 4);
@@ -173,12 +172,12 @@ class APITest : public ::testing::Test {
   }
   template <typename ExceptionT>
   void ExpectAPIThrow(std::string message) {
-    EXPECT_THROW_CONTAINS_MESSAGE(GPUTreeShap(X, model.begin(), model.end(), 1,
-                                              phis.begin(), phis.end()),
-                                  ExceptionT, message);
     EXPECT_THROW_CONTAINS_MESSAGE(
-        GPUTreeShapInteractions(X, model.begin(), model.end(), 1,
-                                phis.begin(), phis.end()),
+        GPUTreeShap(X, model.begin(), model.end(), 1, phis.begin(), phis.end()),
+        ExceptionT, message);
+    EXPECT_THROW_CONTAINS_MESSAGE(
+        GPUTreeShapInteractions(X, model.begin(), model.end(), 1, phis.begin(),
+                                phis.end()),
         ExceptionT, message);
     EXPECT_THROW_CONTAINS_MESSAGE(
         GPUTreeShapTaylorInteractions(X, model.begin(), model.end(), 1,
@@ -187,23 +186,23 @@ class APITest : public ::testing::Test {
   }
 
   thrust::device_vector<float> data;
-  std::vector<PathElement> model;
+  std::vector<PathElement<XgboostSplitCondition>> model;
   DenseDatasetWrapper X;
   thrust::device_vector<float> phis;
 };
 
 TEST_F(APITest, PathTooLong) {
   model.resize(33);
-  model[0] = PathElement(0, -1, 0, 0, 0, 0, 0, 0);
-  for (auto i = 1ull; i < model.size(); i++) {
-    model[i] = PathElement(0, i, 0, 0, 0, 0, 0, 0);
+  model[0] = {0, -1, 0, {0, 0, 0}, 0, 0};
+  for (int64_t i = 1; i < model.size(); i++) {
+    model[i] = {0, i, 0, {0, 0, 0}, 0, 0};
   }
   ExpectAPIThrow<std::invalid_argument>("Tree depth must be <= 32");
 }
 
 TEST_F(APITest, PathVIncorrect) {
-  model = {PathElement(0, -1, 0, 0.0f, 0.0f, false, 0.0, 1.0f),
-           {0, 0, 0, 0.0f, 0.0f, false, 0.0f, 0.5f}};
+  model = {{0, -1, 0, {0.0f, 0.0f, false}, 0.0, 1.0f},
+           {0, 0, 0, {0.0f, 0.0f, false}, 0.0f, 0.5f}};
 
   ExpectAPIThrow<std::invalid_argument>(
       "Leaf value v should be the same across a single path");
@@ -224,20 +223,20 @@ TEST_F(APITest, PhisIncorrectLength) {
 //      6:leaf=0.5,cover=1
 TEST(GPUTreeShap, BasicPaths) {
   const float inf = std::numeric_limits<float>::infinity();
-  std::vector<PathElement> path{
-      PathElement{0, -1, 0, -inf, inf, false, 1.0f, 0.5f},
-      {0, 0, 0, 0.5f, inf, false, 0.6f, 0.5f},
-      {0, 1, 0, 0.5f, inf, false, 2.0f / 3, 0.5f},
-      {0, 2, 0, 0.5f, inf, false, 0.5f, 0.5f},
-      {1, -1, 0, -inf, 0.0f, false, 1.0f, 1.0f},
-      {1, 0, 0, 0.5f, inf, false, 0.6f, 1.0f},
-      {1, 1, 0, 0.5f, inf, false, 2.0f / 3, 1.0f},
-      {1, 2, 0, -inf, 0.5f, false, 0.5f, 1.0f},
-      {2, -1, 0, -inf, 0.0f, false, 1.0f, -1},
-      {2, 0, 0, 0.5f, inf, false, 0.6f, -1.0f},
-      {2, 1, 0, -inf, 0.5f, false, 1.0f / 3, -1.0f},
-      {3, -1, 0, -inf, 0.0f, false, 1.0f, -1.0f},
-      {3, 0, 0, -inf, 0.5f, false, 0.4f, -1.0f}};
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, inf, false}, 1.0f, 0.5f},
+      {0, 0, 0, {0.5f, inf, false}, 0.6f, 0.5f},
+      {0, 1, 0, {0.5f, inf, false}, 2.0f / 3, 0.5f},
+      {0, 2, 0, {0.5f, inf, false}, 0.5f, 0.5f},
+      {1, -1, 0, {-inf, 0.0f, false}, 1.0f, 1.0f},
+      {1, 0, 0, {0.5f, inf, false}, 0.6f, 1.0f},
+      {1, 1, 0, {0.5f, inf, false}, 2.0f / 3, 1.0f},
+      {1, 2, 0, {-inf, 0.5f, false}, 0.5f, 1.0f},
+      {2, -1, 0, {-inf, 0.0f, false}, 1.0f, -1},
+      {2, 0, 0, {0.5f, inf, false}, 0.6f, -1.0f},
+      {2, 1, 0, {-inf, 0.5f, false}, 1.0f / 3, -1.0f},
+      {3, -1, 0, {-inf, 0.0f, false}, 1.0f, -1.0f},
+      {3, 0, 0, {-inf, 0.5f, false}, 0.4f, -1.0f}};
   thrust::device_vector<float> data =
       std::vector<float>({1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
   DenseDatasetWrapper X(data.data().get(), 2, 3);
@@ -259,20 +258,20 @@ TEST(GPUTreeShap, BasicPaths) {
 
 TEST(GPUTreeShap, BasicPathsInteractions) {
   const float inf = std::numeric_limits<float>::infinity();
-  std::vector<PathElement> path{
-      PathElement{0, -1, 0, -inf, inf, false, 1.0f, 0.5f},
-      {0, 0, 0, 0.5f, inf, false, 0.6f, 0.5f},
-      {0, 1, 0, 0.5f, inf, false, 2.0f / 3, 0.5f},
-      {0, 2, 0, 0.5f, inf, false, 0.5f, 0.5f},
-      {1, -1, 0, -inf, 0.0f, false, 1.0f, 1.0f},
-      {1, 0, 0, 0.5f, inf, false, 0.6f, 1.0f},
-      {1, 1, 0, 0.5f, inf, false, 2.0f / 3, 1.0f},
-      {1, 2, 0, -inf, 0.5f, false, 0.5f, 1.0f},
-      {2, -1, 0, -inf, 0.0f, false, 1.0f, -1},
-      {2, 0, 0, 0.5f, inf, false, 0.6f, -1.0f},
-      {2, 1, 0, -inf, 0.5f, false, 1.0f / 3, -1.0f},
-      {3, -1, 0, -inf, 0.0f, false, 1.0f, -1.0f},
-      {3, 0, 0, -inf, 0.5f, false, 0.4f, -1.0f}};
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, inf, false}, 1.0f, 0.5f},
+      {0, 0, 0, {0.5f, inf, false}, 0.6f, 0.5f},
+      {0, 1, 0, {0.5f, inf, false}, 2.0f / 3, 0.5f},
+      {0, 2, 0, {0.5f, inf, false}, 0.5f, 0.5f},
+      {1, -1, 0, {-inf, 0.0f, false}, 1.0f, 1.0f},
+      {1, 0, 0, {0.5f, inf, false}, 0.6f, 1.0f},
+      {1, 1, 0, {0.5f, inf, false}, 2.0f / 3, 1.0f},
+      {1, 2, 0, {-inf, 0.5f, false}, 0.5f, 1.0f},
+      {2, -1, 0, {-inf, 0.0f, false}, 1.0f, -1},
+      {2, 0, 0, {0.5f, inf, false}, 0.6f, -1.0f},
+      {2, 1, 0, {-inf, 0.5f, false}, 1.0f / 3, -1.0f},
+      {3, -1, 0, {-inf, 0.0f, false}, 1.0f, -1.0f},
+      {3, 0, 0, {-inf, 0.5f, false}, 0.4f, -1.0f}};
   thrust::device_vector<float> data =
       std::vector<float>({1.0f, 1.0f, 0.0f, 1.0f, 1.0f, 1.0f});
   DenseDatasetWrapper X(data.data().get(), 2, 3);
@@ -297,19 +296,20 @@ TEST(GPUTreeShap, BasicPathsInteractions) {
 // Test a tree with features occurring multiple times in a path
 TEST(GPUTreeShap, BasicPathsWithDuplicates) {
   const float inf = std::numeric_limits<float>::infinity();
-  std::vector<PathElement> path{{0, -1, 0, -inf, 0.0f, false, 1.0f, 3.0f},
-                                {0, 0, 0, 0.5f, inf, false, 2.0f / 3, 3.0f},
-                                {0, 0, 0, 1.5f, inf, false, 0.5f, 3.0f},
-                                {0, 0, 0, 2.5f, inf, false, 0.5f, 3.0f},
-                                {1, -1, 0, -inf, 0.0f, false, 1.0f, 2.0f},
-                                {1, 0, 0, 0.5f, inf, false, 2.0f / 3.0f, 2.0f},
-                                {1, 0, 0, 1.5f, inf, false, 0.5f, 2.0f},
-                                {1, 0, 0, -inf, 2.5f, false, 0.5f, 2.0f},
-                                {2, -1, 0, -inf, 0.0f, false, 1.0f, 1.0f},
-                                {2, 0, 0, 0.5f, inf, false, 2.0f / 3.0f, 1.0f},
-                                {2, 0, 0, -inf, 1.5f, false, 0.5f, 1.0f},
-                                {3, -1, 0, -inf, 0.0f, false, 1.0f, -1.0f},
-                                {3, 0, 0, -inf, 0.5f, false, 1.0f / 3, -1.0f}};
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, 0.0f, false}, 1.0f, 3.0f},
+      {0, 0, 0, {0.5f, inf, false}, 2.0f / 3, 3.0f},
+      {0, 0, 0, {1.5f, inf, false}, 0.5f, 3.0f},
+      {0, 0, 0, {2.5f, inf, false}, 0.5f, 3.0f},
+      {1, -1, 0, {-inf, 0.0f, false}, 1.0f, 2.0f},
+      {1, 0, 0, {0.5f, inf, false}, 2.0f / 3.0f, 2.0f},
+      {1, 0, 0, {1.5f, inf, false}, 0.5f, 2.0f},
+      {1, 0, 0, {-inf, 2.5f, false}, 0.5f, 2.0f},
+      {2, -1, 0, {-inf, 0.0f, false}, 1.0f, 1.0f},
+      {2, 0, 0, {0.5f, inf, false}, 2.0f / 3.0f, 1.0f},
+      {2, 0, 0, {-inf, 1.5f, false}, 0.5f, 1.0f},
+      {3, -1, 0, {-inf, 0.0f, false}, 1.0f, -1.0f},
+      {3, 0, 0, {-inf, 0.5f, false}, 1.0f / 3, -1.0f}};
   thrust::device_vector<float> data = std::vector<float>({2.0f});
   DenseDatasetWrapper X(data.data().get(), 1, 1);
   size_t num_trees = 1;
@@ -336,9 +336,10 @@ class TestGroupPath : public detail::GroupPath {
   using detail::GroupPath::unique_depth_;
 };
 
-template <typename DatasetT>
-__global__ void TestExtendKernel(DatasetT X, size_t num_path_elements,
-                                 const PathElement* path_elements) {
+template <typename DatasetT, typename SplitConditionT>
+__global__ void TestExtendKernel(
+    DatasetT X, size_t num_path_elements,
+    const PathElement<SplitConditionT>* path_elements) {
   cooperative_groups::thread_block block =
       cooperative_groups::this_thread_block();
   auto group =
@@ -351,8 +352,9 @@ __global__ void TestExtendKernel(DatasetT X, size_t num_path_elements,
   // Test first training instance
   cooperative_groups::coalesced_group active_group =
       cooperative_groups::coalesced_threads();
-  PathElement e = path_elements[active_group.thread_rank()];
-  float one_fraction = detail::GetOneFraction(e, X, 0);
+  PathElement<SplitConditionT> e = path_elements[active_group.thread_rank()];
+  float one_fraction =
+      e.split_condition.EvaluateSplit(X.GetElement(0, e.feature_idx));
   float zero_fraction = e.zero_fraction;
   auto labelled_group = detail::active_labeled_partition(mask, 0);
   TestGroupPath path(labelled_group, zero_fraction, one_fraction);
@@ -405,7 +407,8 @@ __global__ void TestExtendKernel(DatasetT X, size_t num_path_elements,
   }
 
   // Test second training instance
-  one_fraction = detail::GetOneFraction(e, X, 1);
+  one_fraction =
+      e.split_condition.EvaluateSplit(X.GetElement(1, e.feature_idx));
   TestGroupPath path2(labelled_group, zero_fraction, one_fraction);
   path2.Extend();
   assert(path2.unique_depth_ == 1);
@@ -458,21 +461,21 @@ __global__ void TestExtendKernel(DatasetT X, size_t num_path_elements,
 
 TEST(GPUTreeShap, Extend) {
   const float inf = std::numeric_limits<float>::infinity();
-  std::vector<PathElement> path;
-  path.emplace_back(PathElement{0, -1, 0, -inf, 0.0f, false, 1.0f, 1.0f});
-  path.emplace_back(PathElement{0, 0, 0, 0.5f, inf, false, 3.0f / 5, 1.0f});
-  path.emplace_back(PathElement{0, 1, 0, 0.5f, inf, false, 2.0f / 3, 1.0f});
-  path.emplace_back(PathElement{0, 2, 0, -inf, 0.5f, false, 1.0f / 2, 1.0f});
-  thrust::device_vector<PathElement> device_path(path);
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, 0.0f, false}, 1.0f, 1.0f},
+      {0, 0, 0, {0.5f, inf, false}, 3.0f / 5, 1.0f},
+      {0, 1, 0, {0.5f, inf, false}, 2.0f / 3, 1.0f},
+      {0, 2, 0, {-inf, 0.5f, false}, 1.0f / 2, 1.0f}};
+  thrust::device_vector<PathElement<XgboostSplitCondition>> device_path(path);
   thrust::device_vector<float> data =
       std::vector<float>({1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
   DenseDatasetWrapper X(data.data().get(), 2, 3);
   TestExtendKernel<<<1, 32>>>(X, 4, device_path.data().get());
 }
-template <typename DatasetT>
-__global__ void TestExtendMultipleKernel(DatasetT X, size_t n_first,
-                                         size_t n_second,
-                                         const PathElement* path_elements) {
+template <typename DatasetT, typename SplitConditionT>
+__global__ void TestExtendMultipleKernel(
+    DatasetT X, size_t n_first, size_t n_second,
+    const PathElement<SplitConditionT>* path_elements) {
   cooperative_groups::thread_block block =
       cooperative_groups::this_thread_block();
   auto warp =
@@ -485,10 +488,11 @@ __global__ void TestExtendMultipleKernel(DatasetT X, size_t n_first,
       cooperative_groups::coalesced_threads();
   int label = warp.thread_rank() >= n_first;
   auto labeled_group = detail::active_labeled_partition(mask, label);
-  PathElement e = path_elements[warp.thread_rank()];
+  PathElement<SplitConditionT> e = path_elements[warp.thread_rank()];
 
   // Test first training instance
-  float one_fraction = detail::GetOneFraction(e, X, 0);
+  float one_fraction =
+      e.split_condition.EvaluateSplit(X.GetElement(0, e.feature_idx));
   float zero_fraction = e.zero_fraction;
   TestGroupPath path(labeled_group, zero_fraction, one_fraction);
   assert(path.unique_depth_ == 0);
@@ -564,17 +568,17 @@ __global__ void TestExtendMultipleKernel(DatasetT X, size_t n_first,
 
 TEST(GPUTreeShap, ExtendMultiplePaths) {
   const float inf = std::numeric_limits<float>::infinity();
-  std::vector<PathElement> path;
-  path.emplace_back(PathElement{0, -1, 0, -inf, 0.0f, false, 1.0f, 1.0f});
-  path.emplace_back(PathElement{0, 0, 0, 0.5f, inf, false, 3.0f / 5, 1.0f});
-  path.emplace_back(PathElement{0, 1, 0, 0.5f, inf, false, 2.0f / 3, 1.0f});
-  path.emplace_back(PathElement{0, 2, 0, -inf, 0.5f, false, 1.0f / 2, 1.0f});
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, 0.0f, false}, 1.0f, 1.0f},
+      {0, 0, 0, {0.5f, inf, false}, 3.0f / 5, 1.0f},
+      {0, 1, 0, {0.5f, inf, false}, 2.0f / 3, 1.0f},
+      {0, 2, 0, {-inf, 0.5f, false}, 1.0f / 2, 1.0f}};
   // Add the first three elements again
   path.emplace_back(path[0]);
   path.emplace_back(path[1]);
   path.emplace_back(path[2]);
 
-  thrust::device_vector<PathElement> device_path(path);
+  thrust::device_vector<PathElement<XgboostSplitCondition>> device_path(path);
   thrust::device_vector<float> data =
       std::vector<float>({1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
   DenseDatasetWrapper X(data.data().get(), 2, 3);
@@ -736,7 +740,7 @@ class DeterminismTest : public ::testing::Test {
                           num_groups);
   }
 
-  std::vector<PathElement> model;
+  std::vector<PathElement<XgboostSplitCondition>> model;
   TestDataset test_data;
   DenseDatasetWrapper X;
   size_t samples;
@@ -745,8 +749,8 @@ class DeterminismTest : public ::testing::Test {
 };
 
 TEST_F(DeterminismTest, GPUTreeShap) {
-  GPUTreeShap(X, model.begin(), model.end(), num_groups,
-              reference_phis.begin(), reference_phis.end());
+  GPUTreeShap(X, model.begin(), model.end(), num_groups, reference_phis.begin(),
+              reference_phis.end());
 
   for (auto i = 0ull; i < samples; i++) {
     thrust::device_vector<float> phis(reference_phis.size());
@@ -772,8 +776,7 @@ TEST_F(DeterminismTest, GPUTreeShapInteractions) {
 
 TEST_F(DeterminismTest, GPUTreeShapTaylorInteractions) {
   GPUTreeShapTaylorInteractions(X, model.begin(), model.end(), num_groups,
-                                reference_phis.begin(),
-                                reference_phis.end());
+                                reference_phis.begin(), reference_phis.end());
 
   for (auto i = 0ull; i < samples; i++) {
     thrust::device_vector<float> phis(reference_phis.size());
@@ -790,17 +793,17 @@ TEST_F(DeterminismTest, GPUTreeShapTaylorInteractions) {
 TEST(GPUTreeShap, TaylorInteractionsPaperExample) {
   const float inf = std::numeric_limits<float>::infinity();
   float c = 3.0f;
-  std::vector<PathElement> path{
-      PathElement{0, -1, 0, -inf, inf, false, 1.0f, 1.0f},
-      {0, 0, 0, 0.5f, inf, false, 0.0f, 1.0f},
-      {1, -1, 0, -inf, inf, false, 1.0f, 1.0f},
-      {1, 1, 0, 0.5f, inf, false, 0.0f, 1.0f},
-      {2, -1, 0, -inf, inf, false, 1.0f, 1.0f},
-      {2, 2, 0, 0.5f, inf, false, 0.0f, 1.0f},
-      {3, -1, 0, -inf, inf, false, 1.0f, c},
-      {3, 0, 0, 0.5f, inf, false, 0.0f, c},
-      {3, 1, 0, 0.5f, inf, false, 0.0f, c},
-      {3, 2, 0, 0.5f, inf, false, 0.0f, c},
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, inf, false}, 1.0f, 1.0f},
+      {0, 0, 0, {0.5f, inf, false}, 0.0f, 1.0f},
+      {1, -1, 0, {-inf, inf, false}, 1.0f, 1.0f},
+      {1, 1, 0, {0.5f, inf, false}, 0.0f, 1.0f},
+      {2, -1, 0, {-inf, inf, false}, 1.0f, 1.0f},
+      {2, 2, 0, {0.5f, inf, false}, 0.0f, 1.0f},
+      {3, -1, 0, {-inf, inf, false}, 1.0f, c},
+      {3, 0, 0, {0.5f, inf, false}, 0.0f, c},
+      {3, 1, 0, {0.5f, inf, false}, 0.0f, c},
+      {3, 2, 0, {0.5f, inf, false}, 0.0f, c},
   };
   thrust::device_vector<float> data = std::vector<float>({1.0f, 1.0f, 1.0f});
   DenseDatasetWrapper X(data.data().get(), 1, 3);
@@ -820,12 +823,12 @@ TEST(GPUTreeShap, TaylorInteractionsPaperExample) {
 
 TEST(GPUTreeShap, TaylorInteractionsBasic) {
   const float inf = std::numeric_limits<float>::infinity();
-  std::vector<PathElement> path{
-      PathElement{0, -1, 0, -inf, inf, false, 1.0f, 2.0f},
-      {0, 0, 0, 0.5f, inf, false, 0.25f, 2.0f},
-      {0, 1, 0, 0.5f, inf, false, 0.5f, 2.0f},
-      {0, 2, 0, 0.5f, inf, false, 0.6f, 2.0f},
-      {0, 3, 0, 0.5f, inf, false, 1.0f, 2.0f},
+  std::vector<PathElement<XgboostSplitCondition>> path{
+      {0, -1, 0, {-inf, inf, false}, 1.0f, 2.0f},
+      {0, 0, 0, {0.5f, inf, false}, 0.25f, 2.0f},
+      {0, 1, 0, {0.5f, inf, false}, 0.5f, 2.0f},
+      {0, 2, 0, {0.5f, inf, false}, 0.6f, 2.0f},
+      {0, 3, 0, {0.5f, inf, false}, 1.0f, 2.0f},
   };
   thrust::device_vector<float> data =
       std::vector<float>({1.0f, 1.0f, 1.0f, 1.0f});

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -16,11 +16,11 @@
 #pragma once
 #include <GPUTreeShap/gpu_treeshap.h>
 #include <limits>
+#include <numeric>
 #include <random>
 #include <vector>
-#include <numeric>
 
-using PathElement = gpu_treeshap::PathElement;
+namespace gpu_treeshap {
 
 class DenseDatasetWrapper {
   const float* data;
@@ -62,9 +62,10 @@ class TestDataset {
   }
 };
 
-void GenerateModel(std::vector<PathElement>* model, int group, size_t max_depth,
-                   size_t num_features, size_t num_paths, std::mt19937* gen,
-                   float max_v) {
+template <typename SplitConditionT>
+void GenerateModel(std::vector<PathElement<SplitConditionT>>* model, int group,
+                   size_t max_depth, size_t num_features, size_t num_paths,
+                   std::mt19937* gen, float max_v) {
   std::uniform_real_distribution<float> value_dis(-max_v, max_v);
   std::uniform_int_distribution<int64_t> feature_dis(0, num_features - 1);
   std::bernoulli_distribution bern_dis;
@@ -73,8 +74,8 @@ void GenerateModel(std::vector<PathElement>* model, int group, size_t max_depth,
   float z = std::pow(0.5, 1.0 / max_depth);
   for (auto i = 0ull; i < num_paths; i++) {
     float v = value_dis(*gen);
-    model->emplace_back(
-        PathElement{base_path_idx + i, -1, group, -inf, inf, false, 1.0, v});
+    model->emplace_back(PathElement<SplitConditionT>{
+        base_path_idx + i, -1, group, {-inf, inf, false}, 1.0, v});
     for (auto j = 0ull; j < max_depth; j++) {
       float lower_bound = -inf;
       float upper_bound = inf;
@@ -89,20 +90,22 @@ void GenerateModel(std::vector<PathElement>* model, int group, size_t max_depth,
       }
       // Don't make the zero fraction too small
       std::uniform_real_distribution<float> zero_fraction_dis(0.05, 1.0);
-      model->emplace_back(
-          PathElement{base_path_idx + i, feature_dis(*gen), group, lower_bound,
-                      upper_bound, bern_dis(*gen), zero_fraction_dis(*gen), v});
+      model->emplace_back(PathElement<SplitConditionT>{
+          base_path_idx + i,
+          feature_dis(*gen),
+          group,
+          {lower_bound, upper_bound, bern_dis(*gen)},
+          zero_fraction_dis(*gen),
+          v});
     }
   }
 }
 
-std::vector<PathElement> GenerateEnsembleModel(size_t num_groups,
-                                               size_t max_depth,
-                                               size_t num_features,
-                                               size_t num_paths, size_t seed,
-                                               float max_v = 1.0f) {
+std::vector<PathElement<gpu_treeshap::XgboostSplitCondition>>
+GenerateEnsembleModel(size_t num_groups, size_t max_depth, size_t num_features,
+                      size_t num_paths, size_t seed, float max_v = 1.0f) {
   std::mt19937 gen(seed);
-  std::vector<PathElement> model;
+  std::vector<PathElement<gpu_treeshap::XgboostSplitCondition>> model;
   for (auto group = 0llu; group < num_groups; group++) {
     GenerateModel(&model, group, max_depth, num_features, num_paths, &gen,
                   max_v);
@@ -110,8 +113,9 @@ std::vector<PathElement> GenerateEnsembleModel(size_t num_groups,
   return model;
 }
 
-std::vector<float> Predict(const std::vector<PathElement>& model,
-                           const TestDataset& X, size_t num_groups) {
+std::vector<float> Predict(
+    const std::vector<PathElement<gpu_treeshap::XgboostSplitCondition>>& model,
+    const TestDataset& X, size_t num_groups) {
   std::vector<float> predictions(X.num_rows * num_groups);
   for (auto i = 0ull; i < X.num_rows; i++) {
     const float* row = X.host_data.data() + i * X.num_cols;
@@ -133,9 +137,9 @@ std::vector<float> Predict(const std::vector<PathElement>& model,
       if (e.feature_idx != -1) {
         float fval = row[e.feature_idx];
         if (std::isnan(fval)) {
-          valid = valid && e.is_missing_branch;
-        } else if (fval < e.feature_lower_bound ||
-                   fval >= e.feature_upper_bound) {
+          valid = valid && e.split_condition.is_missing_branch;
+        } else if (fval < e.split_condition.feature_lower_bound ||
+                   fval >= e.split_condition.feature_upper_bound) {
           valid = false;
         }
       }
@@ -147,3 +151,4 @@ std::vector<float> Predict(const std::vector<PathElement>& model,
 
   return predictions;
 }
+}  // namespace gpu_treeshap


### PR DESCRIPTION
- Allow custom templated implementations of split functions. Can now use single precision or double precision, <= or < conditions or possibly even categorical splits.

- API no longer accept phis as a pointer and length, now requiring began and ended iterations. This minor changed interface is significantly more flexible, for example if a user wants to rearrange the output they can pass a thrust permutation iterator. Users may also now pass host memory iterators for output (e.g. std::vector).

- Added some functions for tensor indexing, useful in the shap package as outputs need to be transposed into a slightly different format.