### PR TITLE
Fix error message about max depth

### DIFF
--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -1087,7 +1087,7 @@ void ValidatePaths(const PathVectorT& device_paths,
                      path_lengths.end(), too_long_op);
 
   if (invalid_length) {
-    throw std::invalid_argument("Tree depth must be <= 32");
+    throw std::invalid_argument("Tree depth must be < 32");
   }
 
   IncorrectVOp<SplitConditionT> incorrect_v_op{device_paths.data().get()};

--- a/tests/test_gpu_treeshap.cu
+++ b/tests/test_gpu_treeshap.cu
@@ -219,7 +219,7 @@ TEST_F(APITest, PathTooLong) {
   for (size_t i = 1; i < model.size(); i++) {
     model[i] = {0, static_cast<int64_t>(i), 0, {0, 0, 0}, 0, 0};
   }
-  ExpectAPIThrow<std::invalid_argument>("Tree depth must be <= 32");
+  ExpectAPIThrow<std::invalid_argument>("Tree depth must be < 32");
 }
 
 TEST_F(APITest, PathVIncorrect) {


### PR DESCRIPTION
Related: https://github.com/rapidsai/cuml/issues/4110#issuecomment-983376491

A tree of depth `N` will produce a path of length `N + 1` (assuming no duplicate features in the splits). This is because we start counting from 0 when computing the depth of the tree. For example, fitting a decision tree with hyperparameter `max_depth=1` will produce a tree stump with a single split node and two leaf nodes. For the tree stump, the path length is 2.