### PR TITLE
Include thrust/sort header

### DIFF
--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -21,6 +21,7 @@
 #include <thrust/logical.h>
 #include <thrust/reduce.h>
 #include <thrust/host_vector.h>
+#include <thrust/sort.h>
 #include <cub/cub.cuh>
 #include <algorithm>
 #include <functional>

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ mkdir -p build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_GTEST=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARKS=ON
 make -j4
-cmake --build . --target docs_cuml
+cmake --build . --target docs_gputreeshap

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -32,9 +32,6 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-$CC --version
-$CXX --version
-
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -22,7 +22,7 @@ function(add_doxygen_target)
     set(multiValueArgs "")
     cmake_parse_arguments(dox "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     configure_file(${dox_IN_DOXYFILE} ${dox_OUT_DOXYFILE} @ONLY)
-    add_custom_target(docs_cuml
+    add_custom_target(docs_gputreeshap
       ${DOXYGEN_EXECUTABLE} ${dox_OUT_DOXYFILE}
       WORKING_DIRECTORY ${dox_CWD}
       VERBATIM


### PR DESCRIPTION
When building GPUTreeShap as part of cuML, the build runs into the following error:
```
/project/cpp/_skbuild/linux-x86_64-3.8/cmake-build/_deps/gputreeshap-src/GPUTreeShap/gpu_treeshap.h(1156): error: namespace "thrust" has no member "sort"
```

Adding the include of thrust/sort fixes the problem.