### PR TITLE
Correct lambda whose return type needs host evaluation.

### DIFF
--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -904,7 +904,7 @@ void DeduplicatePaths(PathVectorT* device_paths,
   size_t* h_num_runs_out;
   CheckCuda(cudaMallocHost(&h_num_runs_out, sizeof(size_t)));
 
-  auto combine = [] __device__(PathElement<SplitConditionT> a,
+  auto combine = [] __host__ __device__(PathElement<SplitConditionT> a,
                                PathElement<SplitConditionT> b) {
     // Combine duplicate features
     a.split_condition.Merge(b.split_condition);


### PR DESCRIPTION
When compiling with newer versions of libcudacxx ( used by cub ) it will now error out when given device lambda's where the host needs to know the return type.

Solve this by marking the lambda as host and device.