### PR TITLE
Correct #20054-D errors found when compiling on ARM

### DIFF
--- a/GPUTreeShap/gpu_treeshap.h
+++ b/GPUTreeShap/gpu_treeshap.h
@@ -114,16 +114,16 @@ struct PathElement {
   }
 
   /*! Unique path index. */
-  size_t path_idx;
+  size_t path_idx{};
   /*! Feature of this split, -1 indicates bias term. */
-  int64_t feature_idx;
+  int64_t feature_idx{};
   /*! Indicates class for multiclass problems. */
-  int group;
-  SplitConditionT split_condition;
+  int group{};
+  SplitConditionT split_condition{};
   /*! Probability of following this path when feature_idx is not in the active
    * set. */
-  double zero_fraction;
-  float v;  // Leaf weight at the end of the path
+  double zero_fraction{};
+  float v{};  // Leaf weight at the end of the path
 };
 
 // Helper function that accepts an index into a flat contiguous array and the


### PR DESCRIPTION
The nvcc compiler on ARM is more stringent and detects incorrect shared memory usage in kernels. The static shared memory approach only works with default constructor types.

So we update `PathElement` to properly follow default construction rules.