### PR TITLE
Update script input name

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,5 +27,5 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-23.08
     with:
       build_type: pull-request
-      test_script: ci/build_and_test.sh
+      script: ci/build_and_test.sh
       matrix_filter: map(select(.ARCH == "amd64"))


### PR DESCRIPTION
This PR updates the script inputs in `build.yaml` and `test.yaml` from `build_script` and `test_script` to `script`. 

Depends on https://github.com/rapidsai/shared-workflows/pull/191
