### PR TITLE
resolve file_key deprecation warning from rapids-dependency-file-generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
     hooks:
       - id: verify-copyright
         args: ["--fix", "--main-branch", "main"]
+  - repo: https://github.com/rapidsai/dependency-file-generator
+    rev: v1.13.11
+    hooks:
+      - id: rapids-dependency-file-generator
+        args: ["--clean"]
 
 default_language_version:
       python: python3

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 rapids-logger "Generate C++ build & test dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key build \
+  --file-key build \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -13,7 +13,7 @@ rapids-dependency-file-generator \
   --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee "${ENV_YAML_DIR}/env.yaml"
 
-rapids-mamba-retry env create --force -f "${ENV_YAML_DIR}/env.yaml" -n checks
+rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n checks
 conda activate checks
 
 # Run pre-commit checks

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -10,7 +10,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key checks \
+  --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --force -f "${ENV_YAML_DIR}/env.yaml" -n checks


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

Resolves this warning coming from `rapids-dependency-file-generator`.

> /opt/conda/lib/python3.9/site-packages/rapids_dependency_file_generator/cli.py:98: UserWarning: The use of --file_key is deprecated. Use -f or --file-key instead.

And adds the `rapids-dependency-file-generator` pre-commit hook, to catch issues with `dependencies.yaml` at build time.