### PR TITLE
Build and test with CUDA 13.3.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
       - checks
       - cpp-build-test
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
     permissions:
       actions: read
       contents: read
@@ -22,7 +22,7 @@ jobs:
       pull-requests: read
   checks:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.3.0
     with:
       enable_check_generated_files: false
       enable_check_version_files_changed: false
@@ -36,7 +36,7 @@ jobs:
   cpp-build-test:
     needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_and_test.sh

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,6 +104,10 @@ dependencies:
               cuda: "13.2"
             packages:
               - cuda-version=13.2
+          - matrix:
+              cuda: "13.3"
+            packages:
+              - cuda-version=13.3
   cuda:
     common:
       - output_types: conda


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/286

* uses CUDA 13.3.0 to build and test
* updates to CUDA 13.3.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.3.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/574

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.

